### PR TITLE
Jinasuh/wi 31

### DIFF
--- a/web_registry/src/components/PatientDetail/PatientProfileDialog.tsx
+++ b/web_registry/src/components/PatientDetail/PatientProfileDialog.tsx
@@ -81,12 +81,15 @@ const emptyProfile = {
     name: '',
     MRN: '',
     clinicCode: 'Other',
-    depressionTreatmentStatus: 'Other',
     birthdate: new Date(),
+    race: 'White',
     sex: 'Male',
     gender: 'Male',
     pronoun: 'He/Him',
-    race: 'White',
+    primaryOncologyProvider: undefined,
+    primaryCareManager: undefined,
+    depressionTreatmentStatus: undefined,
+    followupSchedule: undefined,
 } as IPatientProfile;
 
 const state = observable<IPatientProfile>(emptyProfile);
@@ -112,7 +115,7 @@ export const AddPatientProfileDialog: FunctionComponent<IAddPatientProfileDialog
         action(() => {
             Object.assign(state, emptyProfile);
         }),
-        []
+        [props.open]
     );
 
     const onValueChange = action((key: string, value: any) => {

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -1,7 +1,6 @@
 import withTheme from '@mui/styles/withTheme';
 import { GridCellParams, GridColDef, GridColumnHeaderParams, GridRowParams } from '@mui/x-data-grid';
 import { addWeeks, compareAsc, differenceInWeeks, format } from 'date-fns';
-import { observer } from 'mobx-react';
 import React, { FunctionComponent } from 'react';
 import { getFollowupWeeks } from 'shared/time';
 import { Table } from 'src/components/common/Table';
@@ -58,7 +57,7 @@ export interface ICaseloadTableProps {
     onPatientClick?: (recordId: string) => void;
 }
 
-export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer((props) => {
+export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => {
     const { patients, onPatientClick } = props;
 
     const onRowClick = (param: GridRowParams) => {
@@ -260,6 +259,6 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer((p
             />
         </TableContainer>
     );
-});
+};
 
 export default CaseloadTable;

--- a/web_registry/src/components/common/AssessmentVis.tsx
+++ b/web_registry/src/components/common/AssessmentVis.tsx
@@ -4,8 +4,8 @@ import withTheme from '@mui/styles/withTheme';
 import { addDays, format } from 'date-fns';
 import { addMonths } from 'date-fns/esm';
 import throttle from 'lodash.throttle';
-import { action, observable } from 'mobx';
-import { observer } from 'mobx-react';
+import { action } from 'mobx';
+import { observer, useLocalObservable } from 'mobx-react';
 import React from 'react';
 import {
     Crosshair,
@@ -103,26 +103,26 @@ interface IAssessmentChartState {
     visibility: LegendItem[];
 }
 
-const state = observable<IAssessmentChartState>({
-    hoveredPoint: undefined,
-    hoveredIndex: undefined,
-    expanded: false,
-    visibility: [],
-});
-
-const onNearestX = throttle(
-    action((point: Point, { index }: RVNearestXData<Point>) => {
-        state.hoveredPoint = point;
-        state.hoveredIndex = index;
-    }),
-    500
-);
-
 export const AssessmentVis = withTheme(
     observer((props: ThemedStyledProps<IAssessmentChartProps, any>) => {
         const ref = React.useRef(null);
         const { width } = useResize(ref);
         const { data, maxValue, useTime } = props;
+
+        const state = useLocalObservable<IAssessmentChartState>(() => ({
+            hoveredPoint: undefined,
+            hoveredIndex: undefined,
+            expanded: false,
+            visibility: [],
+        }));
+
+        const onNearestX = throttle(
+            action((point: Point, { index }: RVNearestXData<Point>) => {
+                state.hoveredPoint = point;
+                state.hoveredIndex = index;
+            }),
+            500
+        );
 
         const dataKeys = !!data && data.length > 0 ? Object.keys(data[0].pointValues) : [];
 


### PR DESCRIPTION
When expanding/refreshing PHQ9/GAD7, the sub items become incorrect. So use local states for each visualization instance.