### PR TITLE
Change Default Assignments in New Patient Population

### DIFF
--- a/scope_shared/scope/database/patients.py
+++ b/scope_shared/scope/database/patients.py
@@ -48,7 +48,7 @@ def create_patient(
     patient_id = scope.database.collection_utils.generate_set_id()
     generated_patient_collection_name = _patient_collection_name(patient_id=patient_id)
 
-    # Ensure this patient id and collection do not already exist
+    # Ensure this patient id and collection do not already exist.
     if get_patient_identity(database=database, patient_id=patient_id) is not None:
         raise ValueError('Patient "{}" already exists'.format(patient_id))
     if generated_patient_collection_name in database.list_collection_names():
@@ -56,7 +56,7 @@ def create_patient(
             'Collection "{}" already exists'.format(generated_patient_collection_name)
         )
 
-    # Create the patient collection with a sentinel document
+    # Create the patient collection with a sentinel document.
     patient_collection = database.get_collection(generated_patient_collection_name)
     result = scope.database.collection_utils.put_singleton(
         collection=patient_collection,
@@ -64,10 +64,12 @@ def create_patient(
         document={},
     )
 
-    # Create the index on the patient collection
+    # Create the index on the patient collection.
     scope.database.collection_utils.ensure_index(collection=patient_collection)
 
-    # Create the initial profile document
+    # Create the initial profile document.
+    # Intentionally minimal,
+    # any more complex defaults should be created in populate.
     patient_profile_document = {
         "_type": scope.database.patient.patient_profile.DOCUMENT_TYPE,
         "name": patient_name,
@@ -84,7 +86,9 @@ def create_patient(
         patient_profile=patient_profile_document,
     )
 
-    # Create the initial clinical history document
+    # Create the initial clinical history document.
+    # Intentionally minimal,
+    # any more complex defaults should be created in populate.
     clinical_history_document = {
         "_type": scope.database.patient.clinical_history.DOCUMENT_TYPE,
     }
@@ -97,13 +101,14 @@ def create_patient(
         clinical_history=clinical_history_document,
     )
 
-    # Use a uniform datetime for the new assignments for this patient
+    # Use a uniform datetime for the new assignments for this patient.
     datetime_assigned = scope.database.date_utils.format_datetime(
         pytz.utc.localize(datetime.datetime.utcnow())
     )
 
-    # Create an initial empty safety plan document
-    # Intentionally minimal, more complex defaults should be created in populate
+    # Create an initial empty safety plan document.
+    # Intentionally minimal and not assigned,
+    # any more complex defaults should be created in populate.
     safety_plan_document = {
         "_type": scope.database.patient.safety_plan.DOCUMENT_TYPE,
         "assigned": False,
@@ -118,8 +123,9 @@ def create_patient(
         safety_plan=safety_plan_document,
     )
 
-    # Create an initial empty values inventory document
-    # Intentionally minimal, more complex defaults should be created in populate
+    # Create an initial empty values inventory document.
+    # Intentionally minimal and not assigned,
+    # any more complex defaults should be created in populate.
     values_inventory_document = {
         "_type": scope.database.patient.values_inventory.DOCUMENT_TYPE,
         "assigned": False,
@@ -134,8 +140,9 @@ def create_patient(
         values_inventory=values_inventory_document,
     )
 
-    # Create initial assessments
-    # Intentionally minimal, more complex defaults should be created in populate
+    # Create initial assessments.
+    # Intentionally minimal and not assigned,
+    # any more complex defaults should be created in populate.
     for assessment_current in [
         scope.enums.AssessmentType.GAD7.value,
         scope.enums.AssessmentType.Medication.value,

--- a/scope_shared/scope/populate/patient/populate_default_data.py
+++ b/scope_shared/scope/populate/patient/populate_default_data.py
@@ -54,81 +54,91 @@ def _populate_default_data(
     collection: pymongo.collection.Collection,
 ):
     """
-    Populate the specific documents we want.
+    Populate the specific documents we want in a "new" patient.
     """
 
     #
     # Default safety plan
+    # - Removed 4/2022 because no default is desired
     #
-    default_safety_plan_document = scope.database.patient.get_safety_plan(
-        collection=collection,
-    )
-    default_safety_plan_document.update(
-        {
-            "assigned": True,
-            # Preserve original assignedDateTime
-        }
-    )
-    del default_safety_plan_document["_id"]
-    scope.database.patient.put_safety_plan(
-        collection=collection,
-        safety_plan=default_safety_plan_document,
-    )
+    # default_safety_plan_document = scope.database.patient.get_safety_plan(
+    #     collection=collection,
+    # )
+    # default_safety_plan_document.update(
+    #     {
+    #         "assigned": True,
+    #         # Preserve original assignedDateTime
+    #     }
+    # )
+    # del default_safety_plan_document["_id"]
+    # scope.database.patient.put_safety_plan(
+    #     collection=collection,
+    #     safety_plan=default_safety_plan_document,
+    # )
 
     #
     # Default values inventory
+    # - Removed 4/2022 because no default is desired
     #
-    default_values_inventory = scope.database.patient.get_values_inventory(
-        collection=collection,
-    )
-    default_values_inventory.update(
-        {
-            "assigned": True,
-            # Preserve original assignedDateTime
-        }
-    )
-    del default_values_inventory["_id"]
-    scope.database.patient.put_values_inventory(
-        collection=collection,
-        values_inventory=default_values_inventory,
-    )
+    # default_values_inventory = scope.database.patient.get_values_inventory(
+    #     collection=collection,
+    # )
+    # default_values_inventory.update(
+    #     {
+    #         "assigned": True,
+    #         # Preserve original assignedDateTime
+    #     }
+    # )
+    # del default_values_inventory["_id"]
+    # scope.database.patient.put_values_inventory(
+    #     collection=collection,
+    #     values_inventory=default_values_inventory,
+    # )
 
+    #
     # Default assignment of GAD-7 assessment
-    default_assessment_gad7 = scope.database.patient.get_assessment(
-        collection=collection,
-        set_id=scope.enums.AssessmentType.GAD7.value,
-    )
-    default_assessment_gad7.update(
-        {
-            "assigned": True,
-            # Preserve original assignedDateTime
-            "frequency": "Every 2 weeks",
-            "dayOfWeek": "Monday",
-        }
-    )
-    del default_assessment_gad7["_id"]
-    scope.database.patient.put_assessment(
-        collection=collection,
-        set_id=scope.enums.AssessmentType.GAD7.value,
-        assessment=default_assessment_gad7,
-    )
+    # - Removed 4/2022 because no default is desired
+    #
+    # default_assessment_gad7 = scope.database.patient.get_assessment(
+    #     collection=collection,
+    #     set_id=scope.enums.AssessmentType.GAD7.value,
+    # )
+    # default_assessment_gad7.update(
+    #     {
+    #         "assigned": True,
+    #         # Preserve original assignedDateTime
+    #         "frequency": "Every 2 weeks",
+    #         "dayOfWeek": "Monday",
+    #     }
+    # )
+    # del default_assessment_gad7["_id"]
+    # scope.database.patient.put_assessment(
+    #     collection=collection,
+    #     set_id=scope.enums.AssessmentType.GAD7.value,
+    #     assessment=default_assessment_gad7,
+    # )
 
+    #
     # Default assignment of PHQ-9 assessment
-    default_assessment_phq9 = scope.database.patient.get_assessment(
-        collection=collection,
-        set_id=scope.enums.AssessmentType.PHQ9.value,
-    )
-    default_assessment_phq9.update(
-        {
-            "assigned": True,
-            # Preserve original assignedDateTime
-            "frequency": "Every 2 weeks",
-            "dayOfWeek": "Monday",
-        }
-    )
-    del default_assessment_phq9["_id"]
-    scope.database.patient.put_assessment(
-        collection=collection,
-        set_id=scope.enums.AssessmentType.PHQ9.value,
-        assessment=default_assessment_phq9,
-    )
+    # - Removed 4/2022 because no default is desired
+    #
+    # default_assessment_phq9 = scope.database.patient.get_assessment(
+    #     collection=collection,
+    #     set_id=scope.enums.AssessmentType.PHQ9.value,
+    # )
+    # default_assessment_phq9.update(
+    #     {
+    #         "assigned": True,
+    #         # Preserve original assignedDateTime
+    #         "frequency": "Every 2 weeks",
+    #         "dayOfWeek": "Monday",
+    #     }
+    # )
+    # del default_assessment_phq9["_id"]
+    # scope.database.patient.put_assessment(
+    #     collection=collection,
+    #     set_id=scope.enums.AssessmentType.PHQ9.value,
+    #     assessment=default_assessment_phq9,
+    # )
+
+    pass


### PR DESCRIPTION
Fixes #268:

- Safety plan no longer assigned by default.
- Values inventory no longer assigned by default.
- GAD7 no longer assigned by default.
- PHQ9 no longer assigned by default.

Relevant:

- Medication tracking was already not assigned by default, continues to not be assigned by default.