### PR TITLE
Fixed assignedDateTime in assessments

### DIFF
--- a/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
+++ b/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
@@ -146,6 +146,7 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> = o
 
     const onSaveConfigure = action(() => {
         const { frequency, dayOfWeek } = configureState;
+        assessment.assignedDateTime = new Date();
         var newAssessment = { ...assessment, frequency, dayOfWeek };
         currentPatient.updateAssessment(newAssessment);
         configureState.openConfigure = false;

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -366,10 +366,10 @@ export class PatientStore implements IPatientStore {
             ),
             primaryCareManager: patientProfile.primaryCareManager
                 ? {
-                      name: patientProfile.primaryCareManager?.name,
-                      providerId: patientProfile.primaryCareManager?.providerId,
-                      role: patientProfile.primaryCareManager?.role,
-                  }
+                    name: patientProfile.primaryCareManager?.name,
+                    providerId: patientProfile.primaryCareManager?.providerId,
+                    role: patientProfile.primaryCareManager?.role,
+                }
                 : undefined,
         });
 
@@ -439,6 +439,7 @@ export class PatientStore implements IPatientStore {
                 ...toJS(found),
                 assessmentId,
                 assigned: true,
+                assignedDateTime: new Date(),
                 frequency: found.frequency || 'Every 2 weeks',
                 dayOfWeek: found.dayOfWeek || 'Monday',
             });


### PR DESCRIPTION
- Registry app: Send date time of click interaction as `assignedDateTime` in assessments #270 