### PR TITLE
Add Schema Checks for Activity Logs

### DIFF
--- a/scope_shared/scope/schema_utils.py
+++ b/scope_shared/scope/schema_utils.py
@@ -14,6 +14,10 @@ def assert_schema(
     schema: jschon.JSONSchema,
     expected_valid: bool = True,
 ):
+    """
+    Assert a document matches a schema.
+    """
+
     result = schema.evaluate(jschon.JSON(data))
     if result.valid != expected_valid:
         schema_output = result.output("detailed")

--- a/scope_shared/scope/schemas/documents/activity-log.json
+++ b/scope_shared/scope/schemas/documents/activity-log.json
@@ -52,5 +52,43 @@
 		}
 	},
 	"additionalProperties": false,
-	"required": ["_type", "scheduledActivityId", "activityId", "activityName", "recordedDateTime"]
+	"required": ["_type", "scheduledActivityId", "activityId", "activityName", "recordedDateTime"],
+	"allOf": [
+		{
+			"$ref": "#/$defs/no-success-disallows-accomplishment"
+		},
+		{
+			"$ref": "#/$defs/no-success-disallows-pleasure"
+		}
+	],
+	"$defs": {
+		"no-success-disallows-accomplishment": {
+			"anyOf": [
+				{
+					"not": { "$ref": "#/$defs/no-success" }
+				},
+				{
+					"not": { "required": ["accomplishment"] }
+				}
+			]
+		},
+		"no-success-disallows-pleasure": {
+			"anyOf": [
+				{
+					"not": { "$ref": "#/$defs/no-success" }
+				},
+				{
+					"not": { "required": ["pleasure"] }
+				}
+			]
+		},
+		"no-success": {
+			"properties": {
+				"success": {
+					"const": "No"
+				}
+			},
+			"required": ["success"]
+		}
+	}
 }

--- a/scope_shared/scope/testing/fake_data/fake_utils.py
+++ b/scope_shared/scope/testing/fake_data/fake_utils.py
@@ -36,6 +36,7 @@ def fake_optional(*, document: dict, optional_keys: List[str]) -> dict:
 
     fake_optional_document = copy.deepcopy(document)
     for key in missing_keys:
-        del fake_optional_document[key]
+        if key in fake_optional_document:
+            del fake_optional_document[key]
 
     return fake_optional_document

--- a/scope_shared/scope/testing/fake_data/fixtures_fake_activity_logs.py
+++ b/scope_shared/scope/testing/fake_data/fixtures_fake_activity_logs.py
@@ -51,10 +51,12 @@ def _fake_activity_logs(
             "alternative": faker_factory.text(),
         }
         if fake_activity_log["success"] != scope.enums.ActivitySuccessType.No.value:
-            fake_activity_log.update({
-                "pleasure": random.randint(1, 10),
-                "accomplishment": random.randint(1, 10),
-            })
+            fake_activity_log.update(
+                {
+                    "pleasure": random.randint(1, 10),
+                    "accomplishment": random.randint(1, 10),
+                }
+            )
         # Remove a randomly sampled subset of optional parameters.
         fake_activity_log = fake_utils.fake_optional(
             document=fake_activity_log,

--- a/scope_shared/scope/testing/fake_data/fixtures_fake_activity_logs.py
+++ b/scope_shared/scope/testing/fake_data/fixtures_fake_activity_logs.py
@@ -49,9 +49,12 @@ def _fake_activity_logs(
             "completed": random.choice([True, False]),
             "success": fake_utils.fake_enum_value(scope.enums.ActivitySuccessType),
             "alternative": faker_factory.text(),
-            "pleasure": random.randint(1, 10),
-            "accomplishment": random.randint(1, 10),
         }
+        if fake_activity_log["success"] != scope.enums.ActivitySuccessType.No.value:
+            fake_activity_log.update({
+                "pleasure": random.randint(1, 10),
+                "accomplishment": random.randint(1, 10),
+            })
         # Remove a randomly sampled subset of optional parameters.
         fake_activity_log = fake_utils.fake_optional(
             document=fake_activity_log,

--- a/scope_shared/scope/testing/test_schemas/json/activity-log/no-success-disallows-accomplishment-and-pleasure-valid.json
+++ b/scope_shared/scope/testing/test_schemas/json/activity-log/no-success-disallows-accomplishment-and-pleasure-valid.json
@@ -1,0 +1,10 @@
+{
+	"_type": "activityLog",
+	"activityId": "1",
+	"activityName": "activityName",
+	"scheduledActivityId": "1",
+	"recordedDateTime": "2022-03-20T14:48:08.000Z",
+	"success": "Yes",
+	"accomplishment": 5,
+	"pleasure": 5
+}

--- a/scope_shared/scope/testing/test_schemas/json/activity-log/no-success-disallows-accomplishment-invalid.json
+++ b/scope_shared/scope/testing/test_schemas/json/activity-log/no-success-disallows-accomplishment-invalid.json
@@ -1,0 +1,9 @@
+{
+	"_type": "activityLog",
+	"activityId": "1",
+	"activityName": "activityName",
+	"scheduledActivityId": "1",
+	"recordedDateTime": "2022-03-20T14:48:08.000Z",
+	"success": "No",
+	"accomplishment": 5
+}

--- a/scope_shared/scope/testing/test_schemas/json/activity-log/no-success-disallows-pleasure-invalid.json
+++ b/scope_shared/scope/testing/test_schemas/json/activity-log/no-success-disallows-pleasure-invalid.json
@@ -1,0 +1,9 @@
+{
+	"_type": "activityLog",
+	"activityId": "1",
+	"activityName": "activityName",
+	"scheduledActivityId": "1",
+	"recordedDateTime": "2022-03-20T14:48:08.000Z",
+	"success": "No",
+	"pleasure": 5
+}

--- a/scope_shared/scope/testing/test_schemas/test_json_schemas.py
+++ b/scope_shared/scope/testing/test_schemas/test_json_schemas.py
@@ -70,6 +70,25 @@ TEST_CONFIGS = [
         document_path="activity/false-hasRepetition-disallows-repeatDayFlags-invalid.json",
         expected_valid=False,
     ),
+    # activity-log
+    ConfigTestJSONSchema(
+        name="activity-log-no-success-disallows-accomplishment-and-pleasure-valid",
+        schema=scope.schema.activity_log_schema,
+        document_path="activity-log/no-success-disallows-accomplishment-and-pleasure-valid.json",
+        expected_valid=True,
+    ),
+    ConfigTestJSONSchema(
+        name="activity-log-no-success-disallows-accomplishment-invalid",
+        schema=scope.schema.activity_log_schema,
+        document_path="activity-log/no-success-disallows-accomplishment-invalid.json",
+        expected_valid=False,
+    ),
+    ConfigTestJSONSchema(
+        name="activity-log-no-success-disallows-pleasure-invalid",
+        schema=scope.schema.activity_log_schema,
+        document_path="activity-log/no-success-disallows-pleasure-invalid.json",
+        expected_valid=False,
+    ),
     # assessment
     ConfigTestJSONSchema(
         name="false-assigned-disallows-dayOfWeek-and-frequency-invalid",

--- a/scope_shared/scope/testing/test_schemas/test_json_schemas.py
+++ b/scope_shared/scope/testing/test_schemas/test_json_schemas.py
@@ -4,8 +4,10 @@ from pprint import pprint
 from typing import Union
 
 import jschon
+import json
 import pytest
 import scope.schema
+import scope.schema_utils
 
 JSON_DATA_PATH = Path(Path(__file__).parent, "json")
 
@@ -259,14 +261,11 @@ def test_json_schema(config: ConfigTestJSONSchema):
         pytest.xfail("Schema failed to parse")
 
     with open(Path(JSON_DATA_PATH, config.document_path), encoding="utf-8") as f:
-        json = f.read()
+        data = f.read()
+        data = json.loads(data)
 
-    result = config.schema.evaluate(jschon.JSON.loads(json)).output("detailed")
-
-    if result["valid"] != config.expected_valid:
-        if not result["valid"]:
-            pprint(json)
-            print()
-            pprint(result)
-
-    assert result["valid"] == config.expected_valid
+    scope.schema_utils.assert_schema(
+        data=data,
+        schema=config.schema,
+        expected_valid=config.expected_valid,
+    )


### PR DESCRIPTION
#308 fixed #288, but did not include a corresponding schema update because we could not detect / fix any pre-existing documents that might conflict with schema update. Now that we can detect pre-existing documents that conflict with a schema, this updates the activity-log schema for the same reasons we made client updates in #308.

Fixes #317.