### PR TITLE
Set Extremely Long Client Timeouts

### DIFF
--- a/web_patient/src/services/appService.ts
+++ b/web_patient/src/services/appService.ts
@@ -11,7 +11,7 @@ class AppService implements IAppService {
     constructor(baseUrl: string) {
         this.axiosInstance = axios.create({
             baseURL: baseUrl,
-            timeout: 15000,
+            timeout: 1000 * 60 * 2,
         });
     }
 

--- a/web_patient/src/services/configService.ts
+++ b/web_patient/src/services/configService.ts
@@ -11,7 +11,7 @@ class ConfigService implements IConfigService {
     constructor(baseUrl: string) {
         this.axiosInstance = axios.create({
             baseURL: baseUrl,
-            timeout: 15000,
+            timeout: 1000 * 60 * 2,
         });
     }
 

--- a/web_registry/src/services/configService.ts
+++ b/web_registry/src/services/configService.ts
@@ -11,7 +11,7 @@ class ConfigService implements IConfigService {
     constructor(baseUrl: string) {
         this.axiosInstance = axios.create({
             baseURL: baseUrl,
-            timeout: 15000,
+            timeout: 1000 * 60 * 2,
         });
     }
 

--- a/web_shared/serviceBase.ts
+++ b/web_shared/serviceBase.ts
@@ -15,7 +15,7 @@ export class ServiceBase implements IServiceBase {
     constructor(baseUrl: string) {
         this.axiosInstance = axios.create({
             baseURL: baseUrl,
-            timeout: 15000,
+            timeout: 1000 * 60 * 2,
         });
 
         const handleDocuments = (body: any) => {


### PR DESCRIPTION
Our current implementation of `/patient` and `/patients` involves many database roundtrips for each patient, so the delay becomes unworkable when Flask is running locally. This dramatically extends the client timeout as a workaround.

This is not yet a critical issue in production, but will need to be fixed there as our number of patients continues to grow.