### PR TITLE
Adjust Columns to Create More Space for Patient Name

### DIFF
--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -136,7 +136,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'name',
             headerName: 'Name',
-            minWidth: 120,
+            minWidth: 240,
             align: 'center',
             headerAlign: 'center',
         },
@@ -157,7 +157,8 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'initialSession',
             headerName: 'Initial Session',
-            minWidth: 80,
+            width: 85,
+            renderHeader,
             align: 'center',
             headerAlign: 'center',
             filterable: false,
@@ -165,7 +166,8 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'recentSession',
             headerName: 'Last Session',
-            minWidth: 80,
+            width: 85,
+            renderHeader,
             align: 'center',
             headerAlign: 'center',
             filterable: false,
@@ -173,7 +175,8 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'recentCaseReview',
             headerName: 'Last Case Review',
-            minWidth: 120,
+            width: 85,
+            renderHeader,
             align: 'center',
             headerAlign: 'center',
             filterable: false,
@@ -181,7 +184,8 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'nextSessionDue',
             headerName: 'Follow-up Due',
-            minWidth: 80,
+            width: 85,
+            renderHeader,
             align: 'center',
             headerAlign: 'center',
             filterable: false,
@@ -234,7 +238,8 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'lastPHQDate',
             headerName: 'Last PHQ-9 Date',
-            minWidth: 120,
+            width: 85,
+            renderHeader,
             align: 'center',
             headerAlign: 'center',
         },
@@ -268,7 +273,8 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = (props) => 
         {
             field: 'lastGADDate',
             headerName: 'Last GAD-7 Date',
-            minWidth: 120,
+            width: 85,
+            renderHeader,
             align: 'center',
             headerAlign: 'center',
         },


### PR DESCRIPTION
This uses the existing `renderHeader` to hack some space out of date columns, allowing us to make the name column wider.

Before and after screenshots below:
- Dates still fit.
- Overall width is not any greater.

It would be better to do this by forcing certain line wraps, continuing to use `minWidth`. But this hacks it in for now.

### Before:

![Screenshot 2022-08-26 at 14-45-27 SCOPE Registry](https://user-images.githubusercontent.com/2163573/186996126-a686c6ae-13ca-4dbe-911f-9cdaed635888.png)

### After:

![Screenshot 2022-08-26 at 14-43-00 SCOPE Registry](https://user-images.githubusercontent.com/2163573/186996141-810d129f-3ea8-4599-9516-dc40834f86b9.png)

