### PR TITLE
Ensure Uniqueness of Created/Edited Value Names

### DIFF
--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -437,11 +437,19 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
     });
 
     const valueValidateName = () => {
-        // Value name must be unique within a life area, accounting for case-insensitive comparisons
+        //
+        // This function effectively duplicates valueValidateName in LifeAreaDetail
+        //
+        // They should be consolidated for avoiding confusion in maintenance
+        //
+
+        // Value name must be unique within a life area,
+        // accounting for case-insensitive comparisons,
+        // and trimming any whitespace
         const nameIsUnique: boolean =
             patientStore.getValuesByLifeAreaId(activityViewState.lifeAreaId).findIndex((value: IValue): boolean => {
-                // Search for a case-insensitive match
-                return value.name.toLocaleLowerCase() == activityViewState.addValueName.toLocaleLowerCase();
+                // Search for a case-insensitive match, trimming any whitespace
+                return value.name.toLocaleLowerCase().trim() == activityViewState.addValueName.toLocaleLowerCase().trim();
             }) < 0;
 
         return nameIsUnique;

--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -437,9 +437,9 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
     });
 
     const valueValidateName = () => {
-        // Value name must be unique, accounting for case-insensitive comparisons
+        // Value name must be unique within a life area, accounting for case-insensitive comparisons
         const nameIsUnique: boolean =
-            patientStore.values.findIndex((value: IValue): boolean => {
+            patientStore.getValuesByLifeAreaId(activityViewState.lifeAreaId).findIndex((value: IValue): boolean => {
                 // Search for a case-insensitive match
                 return value.name.toLocaleLowerCase() == activityViewState.addValueName.toLocaleLowerCase();
             }) < 0;

--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -423,9 +423,9 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
 
     const handleAddValueSave = action(async () => {
         activityViewState.addValueOpen = false;
-
+        const valueName = activityViewState.addValueName.trim();
         const createValue: IValue = {
-            name: activityViewState.addValueName,
+            name: valueName,
             lifeAreaId: activityViewState.lifeAreaId,
             editedDateTime: new Date(),
         };

--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -436,6 +436,17 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
         }
     });
 
+    const valueValidateName = () => {
+        // Value name must be unique, accounting for case-insensitive comparisons
+        const nameIsUnique: boolean =
+            patientStore.values.findIndex((value: IValue): boolean => {
+                // Search for a case-insensitive match
+                return value.name.toLocaleLowerCase() == activityViewState.addValueName.toLocaleLowerCase();
+            }) < 0;
+
+        return nameIsUnique;
+    };
+
     const handleActivityChangeName = action((event: React.ChangeEvent<HTMLInputElement>) => {
         // DisplayedName can only trimStart because full trim means never being able to add a space
         activityViewState.displayedName = event.target.value.trimStart();
@@ -1022,6 +1033,7 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
                 })()}
                 error={patientStore.loadValuesInventoryState.error}
                 loading={patientStore.loadValuesInventoryState.pending}
+                nameIsUnique={valueValidateName}
                 handleCancel={handleAddValueCancel}
                 handleChange={handleAddValueChange}
                 handleSave={handleAddValueSave}

--- a/web_patient/src/components/ValuesInventory/LifeAreaDetail.tsx
+++ b/web_patient/src/components/ValuesInventory/LifeAreaDetail.tsx
@@ -463,13 +463,14 @@ export const LifeAreaDetail: FunctionComponent = observer(() => {
     });
 
     const handleSaveValue = action(async () => {
+        const valueName = viewState.name.trim();
         if (viewState.modeState.mode == 'add') {
             // TODO Activity Refactor: check that our 'add' is valid
             // Defer until this is more cleanly-organized
             // is a unique name
 
             await patientStore.addValue({
-                name: viewState.name,
+                name: valueName,
                 lifeAreaId: lifeAreaId,
                 editedDateTime: new Date(),
             });
@@ -481,7 +482,7 @@ export const LifeAreaDetail: FunctionComponent = observer(() => {
 
             await patientStore.updateValue({
                 ...viewState.modeState.editValue,
-                name: viewState.name,
+                name: valueName,
                 editedDateTime: new Date(),
             });
         }

--- a/web_patient/src/components/ValuesInventory/LifeAreaDetail.tsx
+++ b/web_patient/src/components/ValuesInventory/LifeAreaDetail.tsx
@@ -556,9 +556,10 @@ export const LifeAreaDetail: FunctionComponent = observer(() => {
     });
 
     const valueValidateName = () => {
-        // Value name must be unique, accounting for case-insensitive comparisons
+        // Value name must be unique within the life area, accounting for case-insensitive comparisons
         const nameIsUnique: boolean =
-            patientStore.values
+            patientStore
+                .getValuesByLifeAreaId(lifeAreaId)
                 .filter((value: IValue): boolean => {
                     // In case of edit, do not validate against the value being edited
                     if (viewState.modeState.mode == 'edit') {

--- a/web_patient/src/components/ValuesInventory/LifeAreaDetail.tsx
+++ b/web_patient/src/components/ValuesInventory/LifeAreaDetail.tsx
@@ -557,6 +557,12 @@ export const LifeAreaDetail: FunctionComponent = observer(() => {
     });
 
     const valueValidateName = () => {
+        //
+        // This function effectively duplicates valueValidateName in AddEditActivityForm
+        //
+        // They should be consolidated for avoiding confusion in maintenance
+        //
+
         // Value name must be unique within the life area, accounting for case-insensitive comparisons
         const nameIsUnique: boolean =
             patientStore
@@ -570,8 +576,8 @@ export const LifeAreaDetail: FunctionComponent = observer(() => {
                     return true;
                 })
                 .findIndex((value: IValue): boolean => {
-                    // Search for a case-insensitive match
-                    return value.name.toLocaleLowerCase() == viewState.name.toLocaleLowerCase();
+                    // Search for a case-insensitive match, trimming any whitespace
+                    return value.name.toLocaleLowerCase().trim() == viewState.name.toLocaleLowerCase().trim();
                 }) < 0;
 
         return nameIsUnique;

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -139,6 +139,7 @@ const _strings = {
 
     Values_inventory_dialog_add_value: 'Add value',
     Values_inventory_dialog_add_value_label: 'Name your value',
+    Values_inventory_dialog_value_name_validation_not_unique: 'Value already exists.',
 
     Values_inventory_dialog_edit_value: 'Edit value',
 


### PR DESCRIPTION
It was possible to accidentally create two values in the same area with the same name.

This adds testing for uniqueness at the time of value name creation / editing.

This also ensure value names are trimmed upon creation / editing.

| Before | After |
| ----- | ----- |
| <img width="200" alt="image" src="https://user-images.githubusercontent.com/1428399/227382860-ea228bcf-1657-4d29-b36e-7f021388b395.png">| <img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/48bd2357-bbf2-4c8a-959f-4698cf348d9a"> <img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/82273505-0487-4ab9-9420-129ad09e533b"> <img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/9a092085-65c3-411c-8812-65753cc56885">|
