### PR TITLE
Activity Scheduling: Schedule time cannot be in the past

### DIFF
--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -22,7 +22,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
-import { isEqual } from 'date-fns';
+import { isEqual, isSameDay } from 'date-fns';
 import { action, runInAction } from 'mobx';
 import { observer, useLocalObservable } from 'mobx-react';
 import React, { Fragment, FunctionComponent } from 'react';
@@ -755,6 +755,21 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
             };
         }
 
+        // Check if activityScheduleViewState.displayedDate is today
+        const currentTime = new Date();
+        if (isSameDay(activityScheduleViewState.displayedDate as Date, currentTime)) {
+            // If so, check if the time is in the past
+            const timeOfDayDate = new Date(2023, 0, 1, date.getHours(), date.getMinutes(), 0);
+            const currentTimeDate = new Date(2023, 0, 1, currentTime.getHours(), currentTime.getMinutes(), 0);
+            if (timeOfDayDate < currentTimeDate) {
+                return {
+                    valid: false,
+                    error: true,
+                    errorMessage: getString('form_add_edit_activity_schedule_time_of_day_validation_in_past'),
+                };
+            }
+        }
+
         return {
             valid: true,
             error: false,
@@ -1038,6 +1053,7 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
         activityScheduleViewState.hasRepetition,
         activityScheduleViewState.repeatDayFlags,
     );
+
     const activitySchedulePage = (
         <Stack spacing={4}>
             <FormSection

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -238,7 +238,9 @@ const _strings = {
     form_add_edit_activity_schedule_date_validation_invalid_format: 'Invalid date format.',
     form_add_edit_activity_schedule_time_of_day_label: 'Schedule Time',
     form_add_edit_activity_schedule_time_of_day_help: 'Choose a time you would like to do this activity.',
+    form_add_edit_activity_schedule_time_of_day_validation_in_past: 'Time must be in the future.',
     form_add_edit_activity_schedule_time_of_day_validation_invalid_format: 'Invalid time format.',
+
     form_add_edit_activity_schedule_has_repetition_prompt: 'Would you like to repeat this activity every week?',
     form_add_edit_activity_schedule_repeat_days_prompt: 'On what days would you like to repeat this activity?',
     form_add_edit_activity_schedule_repetition_validation_no_days: 'Select one or more days.',


### PR DESCRIPTION
Issue:
```
Right now people can’t schedule an activity on a date that’s already passed. However, they can schedule an activity that happened earlier in the day. For example, at noon, I can schedule an activity at 11am. We should validate the scheduled time to be past the current time during scheduling. 
```