### PR TITLE
Autoincrementing Dates Fix

### DIFF
--- a/web_patient/src/components/CarePlan/CarePlanPage.tsx
+++ b/web_patient/src/components/CarePlan/CarePlanPage.tsx
@@ -33,7 +33,7 @@ import { getString } from 'src/services/strings';
 import { useStores } from 'src/stores/stores';
 import styled from 'styled-components';
 import { HelperText } from 'src/components/Forms/FormSection';
-import { formatDateOnly, formatDayOfWeekOnly, formatTimeOfDayOnly, getDayOfWeekCount } from 'shared/time';
+import { formatDayOfWeekOnly, formatTimeOfDayOnly, getDayOfWeekCount } from 'shared/time';
 import { sortActivitiesByName, sortActivitySchedulesByDateAndTime } from 'shared/sorting';
 import StatefulDialog from 'src/components/common/StatefulDialog';
 
@@ -242,16 +242,19 @@ export const CarePlanPage: FunctionComponent = observer(() => {
     });
 
     const renderActivitySchedule = (nextTask: IScheduledActivity): ReactNode => {
+        const activitySchedule = patientStore.getActivityScheduleById(nextTask.activityScheduleId);
+
         return (
             <Stack spacing={1}>
                 <HelperText>
-                    {formatDateOnly(nextTask.dueDateTime, 'EEE, MMM d') +
+                    {format(nextTask.dueDateTime, 'EEE, MMM d') +
                         ', ' +
-                        formatTimeOfDayOnly(nextTask.dataSnapshot.activitySchedule.timeOfDay)}
+                        formatTimeOfDayOnly((activitySchedule as IActivitySchedule).timeOfDay)}
                 </HelperText>
-                {nextTask.dataSnapshot.activitySchedule.hasRepetition && (
+
+                {(activitySchedule as IActivitySchedule).hasRepetition && (
                     <HelperText>
-                        {getRepeatDayText(nextTask.dataSnapshot.activitySchedule.repeatDayFlags as DayOfWeekFlags)}
+                        {getRepeatDayText((activitySchedule as IActivitySchedule).repeatDayFlags as DayOfWeekFlags)}
                     </HelperText>
                 )}
             </Stack>
@@ -346,9 +349,8 @@ export const CarePlanPage: FunctionComponent = observer(() => {
                                                         button
                                                         component={Link}
                                                         to={getFormLink(ParameterValues.form.editActivitySchedule, {
-                                                            [Parameters.activityScheduleId as string]: nextTask
-                                                                .dataSnapshot.activitySchedule
-                                                                .activityScheduleId as string,
+                                                            [Parameters.activityScheduleId as string]:
+                                                                nextTask.activityScheduleId as string,
                                                         })}>
                                                         {renderActivitySchedule(nextTask)}
 

--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -278,7 +278,7 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
                 editActivitySchedule.activityScheduleId as string,
             );
 
-            const nextTaskDueDate = toLocalDateOnly(nextTask?.dueDateTime as Date);
+            const nextTaskDueDate = nextTask?.dueDateTime as Date;
 
             return {
                 ...defaultViewState,

--- a/web_patient/src/components/Forms/AddEditActivityForm.tsx
+++ b/web_patient/src/components/Forms/AddEditActivityForm.tsx
@@ -22,7 +22,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
-import { isEqual } from 'date-fns';
+import { isEqual, isSameDay } from 'date-fns';
 import { action, runInAction } from 'mobx';
 import { observer, useLocalObservable } from 'mobx-react';
 import React, { Fragment, FunctionComponent } from 'react';
@@ -755,6 +755,21 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
             };
         }
 
+        // Check if activityScheduleViewState.displayedDate is today
+        const currentTime = new Date();
+        if (isSameDay(activityScheduleViewState.displayedDate as Date, currentTime)) {
+            // If so, check if the time is in the past
+            const timeOfDayDate = new Date(2023, 0, 1, date.getHours(), date.getMinutes(), 0);
+            const currentTimeDate = new Date(2023, 0, 1, currentTime.getHours(), currentTime.getMinutes(), 0);
+            if (timeOfDayDate < currentTimeDate) {
+                return {
+                    valid: false,
+                    error: true,
+                    errorMessage: getString('form_add_edit_activity_schedule_time_of_day_validation_in_past'),
+                };
+            }
+        }
+
         return {
             valid: true,
             error: false,
@@ -1038,6 +1053,7 @@ export const AddEditActivityForm: FunctionComponent<IAddEditActivityFormProps> =
         activityScheduleViewState.hasRepetition,
         activityScheduleViewState.repeatDayFlags,
     );
+
     const activitySchedulePage = (
         <Stack spacing={4}>
             <FormSection

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -238,7 +238,9 @@ const _strings = {
     form_add_edit_activity_schedule_date_validation_invalid_format: 'Invalid date format.',
     form_add_edit_activity_schedule_time_of_day_label: 'Schedule Time',
     form_add_edit_activity_schedule_time_of_day_help: 'Choose a time you would like to do this activity.',
+    form_add_edit_activity_schedule_time_of_day_validation_in_past: 'Time must be in the future.',
     form_add_edit_activity_schedule_time_of_day_validation_invalid_format: 'Invalid time format.',
+
     form_add_edit_activity_schedule_has_repetition_prompt: 'Would you like to repeat this activity every week?',
     form_add_edit_activity_schedule_repeat_days_prompt: 'On what days would you like to repeat this activity?',
     form_add_edit_activity_schedule_repetition_validation_no_days: 'Select one or more days.',


### PR DESCRIPTION
>When I go into edit activity and make an edit (e.g., changing when the days of the week the activity should be repeated) the date of the activity increments by one, e.g., from March 23 -> 24. James thinks it’s because of time zone conversion. 
![image](https://user-images.githubusercontent.com/1428399/229223708-eea2d630-ceca-461e-9053-2bd685d3d721.png)
