### PR TITLE
Update Mood Logging for Crisis Resources

### DIFF
--- a/web_patient/src/components/Forms/FormDialog.tsx
+++ b/web_patient/src/components/Forms/FormDialog.tsx
@@ -44,7 +44,7 @@ export interface IFormDialogProps {
     onClose?: () => void;
     onSubmit?: () => Promise<boolean>;
     pages: IFormPage[];
-    submitToast?: string;
+    submitToast?: string | React.ReactElement;
 }
 
 const ContentContainer = styled.div({

--- a/web_patient/src/components/Forms/MoodLoggingForm.tsx
+++ b/web_patient/src/components/Forms/MoodLoggingForm.tsx
@@ -1,4 +1,4 @@
-import { Slider, TextField } from '@mui/material';
+import { Box, Slider, Stack, TextField } from '@mui/material';
 import withTheme from '@mui/styles/withTheme';
 import { action } from 'mobx';
 import { observer, useLocalObservable } from 'mobx-react';
@@ -110,10 +110,15 @@ export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observe
 
     const submitToast = () => {
         return (
-            <React.Fragment>
-                Thank you for checking in. If you are in crisis or need immediate help,{' '}
-                <Link to={Routes.resources + '/' + Routes.crisisresources}>click here for crisis resources</Link>.
-            </React.Fragment>
+            <Stack spacing={2}>
+                <Box>
+                    { getString('Form_mood_submit_success') } {' '}
+                </Box>
+                <Box>
+                    If you are in crisis or need immediate help, {' '}
+                    <Link to={Routes.resources + '/' + Routes.crisisresources}>click here for crisis resources</Link>.
+                </Box>
+            </Stack>
         );
     };
 

--- a/web_patient/src/components/Forms/MoodLoggingForm.tsx
+++ b/web_patient/src/components/Forms/MoodLoggingForm.tsx
@@ -18,7 +18,7 @@ export interface IMoodLoggingFormProps extends IFormProps {}
 const SliderContainer = withTheme(
     styled.div((props) => ({
         padding: props.theme.spacing(8, 2),
-    })),
+    }))
 );
 
 export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observer(() => {

--- a/web_patient/src/components/Forms/MoodLoggingForm.tsx
+++ b/web_patient/src/components/Forms/MoodLoggingForm.tsx
@@ -112,11 +112,12 @@ export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observe
         return (
             <Stack spacing={2}>
                 <Box>
-                    { getString('Form_mood_submit_success') } {' '}
+                    { getString('Form_mood_submit_success_1') }
                 </Box>
                 <Box>
-                    If you are in crisis or need immediate help, {' '}
-                    <Link to={Routes.resources + '/' + Routes.crisisresources}>click here for crisis resources</Link>.
+                    { getString('Form_mood_submit_success_2_before_link') }
+                    <Link to={Routes.resources + '/' + Routes.crisisresources}>{ getString('Form_mood_submit_success_2_within_link') }</Link>
+                    { getString('Form_mood_submit_success_2_after_link') }
                 </Box>
             </Stack>
         );

--- a/web_patient/src/components/Forms/MoodLoggingForm.tsx
+++ b/web_patient/src/components/Forms/MoodLoggingForm.tsx
@@ -3,10 +3,12 @@ import withTheme from '@mui/styles/withTheme';
 import { action } from 'mobx';
 import { observer, useLocalObservable } from 'mobx-react';
 import React, { FunctionComponent } from 'react';
+import { Link } from 'react-router-dom';
 import { IMoodLog } from 'shared/types';
 import FormDialog from 'src/components/Forms/FormDialog';
 import FormSection from 'src/components/Forms/FormSection';
 import { IFormProps } from 'src/components/Forms/GetFormDialog';
+import { Routes } from 'src/services/routes';
 import { getString } from 'src/services/strings';
 import { useStores } from 'src/stores/stores';
 import styled from 'styled-components';
@@ -16,7 +18,7 @@ export interface IMoodLoggingFormProps extends IFormProps {}
 const SliderContainer = withTheme(
     styled.div((props) => ({
         padding: props.theme.spacing(8, 2),
-    }))
+    })),
 );
 
 export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observer(() => {
@@ -106,6 +108,15 @@ export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observe
         }
     });
 
+    const submitToast = () => {
+        return (
+            <React.Fragment>
+                Thank you for checking in. If you are in crisis or need immediate help,{' '}
+                <Link to={Routes.resources + '/' + Routes.crisisresources}>click here for crisis resources</Link>.
+            </React.Fragment>
+        );
+    };
+
     return (
         <FormDialog
             title={getString('Form_mood_logging_title')}
@@ -114,7 +125,7 @@ export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observe
             loading={patientStore.loadMoodLogsState.pending}
             pages={getMoodLoggingPages()}
             onSubmit={handleSubmit}
-            submitToast={getString('Form_mood_submit_success')}
+            submitToast={submitToast()}
         />
     );
 });

--- a/web_patient/src/components/Resources/CrisisResourcesPage.tsx
+++ b/web_patient/src/components/Resources/CrisisResourcesPage.tsx
@@ -3,6 +3,7 @@ import { action } from 'mobx';
 import React, { FunctionComponent } from 'react';
 import { useNavigate } from 'react-router';
 import { DetailPage } from 'src/components/common/DetailPage';
+import { Routes } from 'src/services/routes';
 import { getString } from 'src/services/strings';
 import styled, { withTheme } from 'styled-components';
 
@@ -24,7 +25,7 @@ export const CrisisResourcesPage: FunctionComponent = () => {
     const navigate = useNavigate();
 
     const handleGoBack = action(() => {
-        navigate(-1);
+        navigate('/' + Routes.resources);
     });
 
     return (
@@ -44,14 +45,14 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                     <ListDiv>
                         <li>
                             <Typography variant="body1">
-                                Suicide & Crisis Lifeline - Call {' '}
+                                Suicide & Crisis Lifeline - Call{' '}
                                 <Link
                                     href="tel:988/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     988
-                                </Link>
-                                {' '} or {' '}
+                                </Link>{' '}
+                                or{' '}
                                 <Link
                                     href="tel:18002738255/"
                                     target="_blank"
@@ -62,7 +63,7 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                         </li>
                         <li>
                             <Typography variant="body1">
-                                Lifeline Web Chat - {' '}
+                                Lifeline Web Chat -{' '}
                                 <Link
                                     href="https://suicidepreventionlifeline.org/chat/"
                                     target="_blank"
@@ -73,21 +74,21 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                         </li>
                         <li>
                             <Typography variant="body1">
-                                Crisis Text Line - {' '}
+                                Crisis Text Line -{' '}
                                 <Link
                                     href="https://www.crisistextline.org/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     https://www.crisistextline.org/
-                                </Link>
-                                {' '} - Text {' '}
+                                </Link>{' '}
+                                - Text{' '}
                                 <Link
                                     href="sms:988/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     988
-                                </Link>
-                                {' '} or Text "HOME" to {' '}
+                                </Link>{' '}
+                                or Text "HOME" to{' '}
                                 <Link
                                     href="sms:741741/"
                                     target="_blank"

--- a/web_patient/src/components/Resources/CrisisResourcesPage.tsx
+++ b/web_patient/src/components/Resources/CrisisResourcesPage.tsx
@@ -45,14 +45,14 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                     <ListDiv>
                         <li>
                             <Typography variant="body1">
-                                Suicide & Crisis Lifeline - Call{' '}
+                                Suicide & Crisis Lifeline - Call {' '}
                                 <Link
                                     href="tel:988/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     988
-                                </Link>{' '}
-                                or{' '}
+                                </Link>
+                                {' '} or {' '}
                                 <Link
                                     href="tel:18002738255/"
                                     target="_blank"
@@ -63,7 +63,7 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                         </li>
                         <li>
                             <Typography variant="body1">
-                                Lifeline Web Chat -{' '}
+                                Lifeline Web Chat - {' '}
                                 <Link
                                     href="https://suicidepreventionlifeline.org/chat/"
                                     target="_blank"
@@ -74,21 +74,21 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                         </li>
                         <li>
                             <Typography variant="body1">
-                                Crisis Text Line -{' '}
+                                Crisis Text Line - {' '}
                                 <Link
                                     href="https://www.crisistextline.org/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     https://www.crisistextline.org/
-                                </Link>{' '}
-                                - Text{' '}
+                                </Link> {' '}
+                                - Text {' '}
                                 <Link
                                     href="sms:988/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     988
-                                </Link>{' '}
-                                or Text "HOME" to{' '}
+                                </Link> {' '}
+                                or Text "HOME" to {' '}
                                 <Link
                                     href="sms:741741/"
                                     target="_blank"

--- a/web_patient/src/components/Resources/CrisisResourcesPage.tsx
+++ b/web_patient/src/components/Resources/CrisisResourcesPage.tsx
@@ -25,6 +25,15 @@ export const CrisisResourcesPage: FunctionComponent = () => {
     const navigate = useNavigate();
 
     const handleGoBack = action(() => {
+        // TODO: Determine if there is a better way to do this.
+        // It's usually sufficient to just go back in the stack (i.e., -1).
+        // But this resource page can be reached by either:
+        // - Navigating downward through resources.
+        // - Or direct linking from elsewhere in the map (i.e., submission of a mood report).
+        // When direct linked to this, going "back" can be problematic.
+        // For example, take us back to a mood report that we've already submitted.
+        // Hard coding the "back" destination to be "up" ensure a reasonable behavior.
+        // I would prefer to not do this (e.g., perhaps by manipulating the "back" stack instead).
         navigate('/' + Routes.resources);
     });
 

--- a/web_patient/src/components/Resources/CrisisResourcesPage.tsx
+++ b/web_patient/src/components/Resources/CrisisResourcesPage.tsx
@@ -80,15 +80,15 @@ export const CrisisResourcesPage: FunctionComponent = () => {
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     https://www.crisistextline.org/
-                                </Link> {' '}
-                                - Text {' '}
+                                </Link>
+                                {' '} - Text {' '}
                                 <Link
                                     href="sms:988/"
                                     target="_blank"
                                     sx={{ display: 'inline-block', overflowWrap: 'anywhere' }}>
                                     988
-                                </Link> {' '}
-                                or Text "HOME" to {' '}
+                                </Link>
+                                {' '} or Text "HOME" to {' '}
                                 <Link
                                     href="sms:741741/"
                                     target="_blank"

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -41,9 +41,9 @@ const _strings = {
     Form_mood_logging_mood_good: 'High',
     Form_mood_logging_comment_prompt: 'Do you have any other notes?',
     Form_mood_logging_comment_help:
-        'You can use the space below to record notes about mood or any events that may be affecting your mood. This information will be available to your clinical social worker (responses may not be reviewed right away).',
+        'You can use the space below to record notes about mood or any events that may be affecting your mood. This information will be available to your clinical social worker, but responses may not be reviewed right away.',
     Form_mood_submit_success:
-        'Thank you for checking in. Your responses will be available to your clinical social worker.',
+        'Thank you for checking in. Your responses will be available to your clinical social worker, but may not be reviewed right away.',
 
     Form_assessment_checkin_title: 'Check-In',
     Form_assessment_score_column_name: 'Score',

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -42,8 +42,14 @@ const _strings = {
     Form_mood_logging_comment_prompt: 'Do you have any other notes?',
     Form_mood_logging_comment_help:
         'You can use the space below to record notes about mood or any events that may be affecting your mood. This information will be available to your clinical social worker, but responses may not be reviewed right away.',
-    Form_mood_submit_success:
-        'Thank you for checking in. Your responses will be available to your clinical social worker, but may not be reviewed right away.',
+    Form_mood_submit_success_1:
+        'Thank you for checking in. This information will be available to your clinical social worker, but responses may not be reviewed right away.',
+    Form_mood_submit_success_2_before_link:
+        'If you are in crisis or need immediate help, resources are available in ',
+    Form_mood_submit_success_2_within_link:
+        'Crisis Help',
+    Form_mood_submit_success_2_after_link:
+        '.',
 
     Form_assessment_checkin_title: 'Check-In',
     Form_assessment_score_column_name: 'Score',

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -41,7 +41,7 @@ const _strings = {
     Form_mood_logging_mood_good: 'High',
     Form_mood_logging_comment_prompt: 'Do you have any other notes?',
     Form_mood_logging_comment_help:
-        'You can use the space below to record notes about mood or any events that may be affecting your mood. This information will be available to your clinical social worker.',
+        'You can use the space below to record notes about mood or any events that may be affecting your mood. This information will be available to your clinical social worker (responses may not be reviewed right away).',
     Form_mood_submit_success:
         'Thank you for checking in. Your responses will be available to your clinical social worker.',
 


### PR DESCRIPTION
Adds text to the mood logging screen clarifying it may not be reviewed right away:

| Before | After |
| ----- | ----- |
| ![mood_checkin_before](https://github.com/uwscope/scope-web/assets/2163573/fc26b5e4-104c-4b10-9bcb-64440fa18172) | ![Screenshot 2023-06-26 at 12-34-56 SCOPE App](https://github.com/uwscope/scope-web/assets/2163573/c93221cb-bd33-492b-a570-ecd2767f1b4e) |


Adds a link to crisis resources in the follow-up toast:

| Before | After |
| ----- | ----- |
| ![toast_before](https://github.com/uwscope/scope-web/assets/2163573/a46ba5c4-cde0-45ed-9a00-6c5650e97812) | ![Screenshot 2023-06-26 at 12-35-18 SCOPE App](https://github.com/uwscope/scope-web/assets/2163573/0abc8b8c-ddc8-411d-8b62-1ca91ff9e811) |


Fixes #398 