### PR TITLE
Update Values Inventory with Link to Activity Ideas

### DIFF
--- a/server_flask/app_config/patient_resources/3bamodel.json
+++ b/server_flask/app_config/patient_resources/3bamodel.json
@@ -7,11 +7,11 @@
       "filename": "Paying_Closer_Attention.pdf"
     },
     {
-      "name": "Activity Menu: General",
+      "name": "Activity Ideas: General",
       "filename": "Actvity_Menu-General.pdf"
     },
     {
-      "name": "Activity Menu: COVID",
+      "name": "Activity Ideas: COVID",
       "filename": "Activity_Menu-COVID.pdf"
     },
     {

--- a/web_patient/src/components/ValuesInventory/ValuesInventoryHome.tsx
+++ b/web_patient/src/components/ValuesInventory/ValuesInventoryHome.tsx
@@ -32,6 +32,7 @@ export const ValuesInventoryHome: FunctionComponent = observer(() => {
             <InstructionText paragraph>{getString('values_inventory_home_instruction2')}</InstructionText>
             <InstructionText paragraph>{getString('values_inventory_home_instruction3')}</InstructionText>
             <InstructionText paragraph>{getString('values_inventory_home_instruction4')}</InstructionText>
+            <InstructionText paragraph>{getString('values_inventory_home_instruction5')}</InstructionText>
             <ContentLoader
                 state={patientStore.loadValuesInventoryState}
                 name="values & activities inventory"

--- a/web_patient/src/components/ValuesInventory/ValuesInventoryHome.tsx
+++ b/web_patient/src/components/ValuesInventory/ValuesInventoryHome.tsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import ContentLoader from 'src/components/Chrome/ContentLoader';
 import DetailPage from 'src/components/common/DetailPage';
 import { getActivitiesCountString, getLifeAreaIcon, getValuesCountString } from 'src/components/ValuesInventory/values';
+import { Routes } from 'src/services/routes';
 import { getString } from 'src/services/strings';
 import { useStores } from 'src/stores/stores';
 import { LifeAreaIdOther } from 'shared/enums';
@@ -30,7 +31,11 @@ export const ValuesInventoryHome: FunctionComponent = observer(() => {
         <DetailPage title={getString('values_inventory_home_title')} onBack={handleGoBack}>
             <InstructionText paragraph>{getString('values_inventory_home_instruction1')}</InstructionText>
             <InstructionText paragraph>{getString('values_inventory_home_instruction2')}</InstructionText>
-            <InstructionText paragraph>{getString('values_inventory_home_instruction3')}</InstructionText>
+            <InstructionText paragraph>
+                {getString('values_inventory_home_instruction3_before_link')}
+                <Link to={'/' + Routes.resources + '/' + Routes.worksheets}>{getString('values_inventory_home_instruction3_within_link')}</Link>
+                {getString('values_inventory_home_instruction3_after_link')}
+            </InstructionText>
             <InstructionText paragraph>{getString('values_inventory_home_instruction4')}</InstructionText>
             <InstructionText paragraph>{getString('values_inventory_home_instruction5')}</InstructionText>
             <ContentLoader

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -92,8 +92,10 @@ const _strings = {
     values_inventory_home_instruction2:
         'The Values & Activities inventory will be useful in collaborating with your care team by identifying what values are important to you and what activities might support those values.',
     values_inventory_home_instruction3:
+        'Need help with ideas for activities? Check out a list of Activities Menu in the Tools > Library.',
+    values_inventory_home_instruction4:
         'The inventory consists of five life areas. You can fill them out in any order.',
-    values_inventory_home_instruction4: 'Tap on any life area to start.',
+    values_inventory_home_instruction5: 'Tap on any life area to start.',
 
     values_inventory_life_area_other_activities_name: 'Other Activities',
     values_inventory_life_area_other_activities_title: 'Not Currently Assigned To Values',

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -91,8 +91,12 @@ const _strings = {
         'Staying active in things that are important to you is very important in maintaining your health and quality of life.',
     values_inventory_home_instruction2:
         'The Values & Activities inventory will be useful in collaborating with your care team by identifying what values are important to you and what activities might support those values.',
-    values_inventory_home_instruction3:
-        'Need help with ideas for activities? Check out a list of Activities Menu in the Tools > Library.',
+    values_inventory_home_instruction3_before_link:
+        'Need help with ideas for activities? Check out Activity Ideas in the ',
+    values_inventory_home_instruction3_within_link:
+        'Library',
+    values_inventory_home_instruction3_after_link:
+        '.',
     values_inventory_home_instruction4:
         'The inventory consists of five life areas. You can fill them out in any order.',
     values_inventory_home_instruction5: 'Tap on any life area to start.',


### PR DESCRIPTION
Added requested link to Activity Ideas in Values & Activities Inventory:

| Before | After |
| ----- | ----- |
| ![before_inventory](https://github.com/uwscope/scope-web/assets/2163573/59cd7240-74e9-4732-80bf-362415e56576) | ![after_inventory](https://github.com/uwscope/scope-web/assets/2163573/01afe3b2-f3d8-4fc0-8945-3a3090532d25) |

Renamed "Activity Menu" to "Activity Ideas" because of confusion when describing it from anywhere else:

| Before | After |
| ----- | ----- |
| ![before_library](https://github.com/uwscope/scope-web/assets/2163573/6b5e6818-d352-4192-bc07-358f67a03f64) | ![after_library](https://github.com/uwscope/scope-web/assets/2163573/a7e4504d-afdf-4203-95b3-67867385d371) |
