### PR TITLE
Robustness Fix for #430

### DIFF
--- a/web_patient/src/components/Forms/MoodLoggingForm.tsx
+++ b/web_patient/src/components/Forms/MoodLoggingForm.tsx
@@ -116,7 +116,7 @@ export const MoodLoggingForm: FunctionComponent<IMoodLoggingFormProps> = observe
                 </Box>
                 <Box>
                     { getString('Form_mood_submit_success_2_before_link') }
-                    <Link to={Routes.resources + '/' + Routes.crisisresources}>{ getString('Form_mood_submit_success_2_within_link') }</Link>
+                    <Link to={'/' + Routes.resources + '/' + Routes.crisisresources}>{ getString('Form_mood_submit_success_2_within_link') }</Link>
                     { getString('Form_mood_submit_success_2_after_link') }
                 </Box>
             </Stack>


### PR DESCRIPTION
Robustness fix for #430.

Existing code works fine, but coincidentally because the included link was from a page at the root. Making the leading slash explicit to help with future copy-paste.