### PR TITLE
Updated Titles for Medication "Changes" versus "Notes"

### DIFF
--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -164,8 +164,8 @@ const SessionEdit: FunctionComponent<ISessionEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Current medications"
-                helperText="Psychotropic and other relevant medications (e.g., steroids, hormone therapies, opioids, etc.)"
+                label="Current Medications"
+                helperText="Psychotropic and other relevant medications (e.g., steroids, hormone therapies, opioids)."
                 value={session.currentMedications}
                 onChange={(text) => onSessionValueChange('currentMedications', text)}
             />
@@ -216,7 +216,7 @@ const SessionEdit: FunctionComponent<ISessionEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Other recommendations / action items"
+                label="Other Recommendations / Action Items"
                 value={session.otherRecommendations}
                 onChange={(text) => onSessionValueChange('otherRecommendations', text)}
             />
@@ -279,7 +279,7 @@ const ReviewEdit: FunctionComponent<IReviewEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Behavioral strategy changes"
+                label="Behavioral Strategy Changes"
                 value={review.behavioralStrategyChange}
                 placeholder="Leave blank if no change to behavioral strategies"
                 onChange={(text) => onReviewValueChange('behavioralStrategyChange', text)}
@@ -290,7 +290,7 @@ const ReviewEdit: FunctionComponent<IReviewEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Referral changes"
+                label="Referral Changes"
                 value={review.referralsChange}
                 placeholder="Leave blank if no change to referrals"
                 onChange={(text) => onReviewValueChange('referralsChange', text)}
@@ -301,7 +301,7 @@ const ReviewEdit: FunctionComponent<IReviewEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Other recommendations / action items"
+                label="Other Recommendations / Action Items"
                 value={review.otherRecommendations}
                 onChange={(text) => onReviewValueChange('otherRecommendations', text)}
             />

--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -268,7 +268,7 @@ const ReviewEdit: FunctionComponent<IReviewEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Medication changes"
+                label="Medication Changes"
                 value={review.medicationChange}
                 placeholder="Leave blank if no change in current medications"
                 onChange={(text) => onReviewValueChange('medicationChange', text)}

--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -153,7 +153,7 @@ const SessionEdit: FunctionComponent<ISessionEditProps> = observer((props) => {
                 multiline={true}
                 minLine={4}
                 maxLine={4}
-                label="Medication changes"
+                label="Medication Notes"
                 value={session.medicationChange}
                 placeholder="Leave blank if no change in current medications"
                 onChange={(text) => onSessionValueChange('medicationChange', text)}

--- a/web_registry/src/components/PatientDetail/SessionReviewTable.tsx
+++ b/web_registry/src/components/PatientDetail/SessionReviewTable.tsx
@@ -88,7 +88,7 @@ export const SessionReviewTable: FunctionComponent<ISessionReviewTableProps> = (
         },
         {
             field: 'medications',
-            headerName: 'Med Changes',
+            headerName: 'Med Changes / Notes',
             width: 150,
             renderHeader,
             renderCell: renderMultilineCell,


### PR DESCRIPTION
Session Information Changed from "Medication Changes" to "Medication Notes":

| Before | After |
| ----- | ----- |
| ![session_before](https://github.com/uwscope/scope-web/assets/2163573/73258409-d0e6-4719-adf2-998fac9212b5) | ![session_after](https://github.com/uwscope/scope-web/assets/2163573/d8225906-4505-4a39-b957-a1d909788fe5) |

Case Review Remains "Medication Changes":

| Before | After |
| ----- | ----- |
| ![review_before](https://github.com/uwscope/scope-web/assets/2163573/daafcfb7-36d6-4468-8bbd-a118a63fd9a5) | ![review_after](https://github.com/uwscope/scope-web/assets/2163573/6f516d96-9d98-49e6-bdf3-f40814b52332) |

Table Changed from "Med Changes" to "Med Changes / Notes":

| Before | After |
| ----- | ----- |
| ![table_before](https://github.com/uwscope/scope-web/assets/2163573/d6a4b5fb-8006-454b-a24a-e676e5e8c40f) | ![table_after](https://github.com/uwscope/scope-web/assets/2163573/f30bcc24-fd18-44e2-8cb6-3fcc3b1d3881) |

Fixes #347.