### PR TITLE
Add Error Handling in Password Entry and Creation

### DIFF
--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -59,7 +59,7 @@ const LoginForm: FunctionComponent<{
                     margin="normal"
                     variant="standard"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(e) => setEmail(e.target.value.replace(/\s/g, ''))}
                     InputLabelProps={{
                         shrink: true,
                     }}
@@ -78,7 +78,7 @@ const LoginForm: FunctionComponent<{
                     variant="standard"
                     margin="normal"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => setPassword(e.target.value.replace(/\s/g, ''))}
                     InputLabelProps={{
                         shrink: true,
                     }}

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -32,20 +32,20 @@ const LoginForm: FunctionComponent<{
     error?: string;
 }> = (props) => {
     const { onLogin, error } = props;
-    const [email, setEmail] = useState('');
+    const [account, setAccount] = useState('');
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
 
     const onSubmit = () => {
         // Trim the password in case it has a trailing space
-        onLogin && onLogin(email, password.trim());
+        onLogin && onLogin(account, password.trim());
     };
 
     const togglePassword = () => {
         setShowPassword(!showPassword);
     };
 
-    const canLogin = !!email && !!password;
+    const canLogin = !!account && !!password;
 
     return (
         <Fragment>
@@ -59,8 +59,8 @@ const LoginForm: FunctionComponent<{
                     required
                     margin="normal"
                     variant="standard"
-                    value={email}
-                    onChange={(e) => setEmail(
+                    value={account}
+                    onChange={(e) => setAccount(
                         // Username cannot include whitespace.
                         e.target.value.replace(/\s/g, '')
                     )}

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -37,7 +37,8 @@ const LoginForm: FunctionComponent<{
     const [showPassword, setShowPassword] = useState(false);
 
     const onSubmit = () => {
-        onLogin && onLogin(email, password);
+        // Trim the password in case it has a trailing space
+        onLogin && onLogin(email, password.trim());
     };
 
     const togglePassword = () => {
@@ -84,7 +85,9 @@ const LoginForm: FunctionComponent<{
                     onChange={(e) => setPassword(
                         // Password can include an interior space,
                         // but cannot include any other whitespace.
-                        e.target.value.replace(/[\t\r\n\f]/g, '').trim()
+                        // We must allow a right-side space for now,
+                        // as additional typing could turn it into an interior space.
+                        e.target.value.replace(/[\t\r\n\f]/g, '').trimLeft()
                     )}
                     InputLabelProps={{
                         shrink: true,

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -59,7 +59,10 @@ const LoginForm: FunctionComponent<{
                     margin="normal"
                     variant="standard"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value.replace(/\s/g, ''))}
+                    onChange={(e) => setEmail(
+                        // Username cannot include whitespace.
+                        e.target.value.replace(/\s/g, '')
+                    )}
                     InputLabelProps={{
                         shrink: true,
                     }}
@@ -78,7 +81,11 @@ const LoginForm: FunctionComponent<{
                     variant="standard"
                     margin="normal"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value.replace(/\s/g, ''))}
+                    onChange={(e) => setPassword(
+                        // Password can include an interior space,
+                        // but cannot include any other whitespace.
+                        e.target.value.replace(/[\t\r\n\f]/g, '').trim()
+                    )}
                     InputLabelProps={{
                         shrink: true,
                     }}

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -88,7 +88,7 @@ const LoginForm: FunctionComponent<{
                         // We must allow a right-side space for now,
                         // as additional typing could turn it into an interior space.
                         // We will then trim the string whenever extracting it from this field.
-                        e.target.value.replace(/[\t\r\n\f]/g, '').trimLeft()
+                        e.target.value.replace(/[\t\r\n\f]/g, '').trimStart()
                     )}
                     InputLabelProps={{
                         shrink: true,

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -87,6 +87,7 @@ const LoginForm: FunctionComponent<{
                         // but cannot include any other whitespace.
                         // We must allow a right-side space for now,
                         // as additional typing could turn it into an interior space.
+                        // We will then trim the string whenever extracting it from this field.
                         e.target.value.replace(/[\t\r\n\f]/g, '').trimLeft()
                     )}
                     InputLabelProps={{
@@ -133,15 +134,40 @@ const PasswordUpdateForm: FunctionComponent<{
     const [passwordRepeat, setPasswordRepeat] = useState('');
     const [showPassword, setShowPassword] = useState(false);
 
+    const validPassword =
+        // Password exists
+        !!password &&
+        // Allowable length
+        (password.length >= 8) &&
+        (password.length <= 128) &&
+        // No space (e.g., no interior space)
+        // Cognito will allow an interior space, but we will not
+        !!password.match(/^\S+$/) &&
+        // Require uppercase
+        !!password.match(/(?=.*[A-Z])/) &&
+        // Require lowercase
+        !!password.match(/(?=.*[a-z])/) &&
+        // Require digit
+        !!password.match(/(?=.*[0-9])/) &&
+        // Require symbol
+        // Defined by Cognito as ^ $ * . [ ] { } ( ) ? " ! @ # % & / \ , > < ' : ; | _ ~ ` = + -
+        // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html
+        !!password.match(/(?=.*[\^$*.\[\]{}\(\)?“!@#%&/\\,><\’:;|_~`=+\-])/);
+
+    const canSubmit: boolean =
+        validPassword &&
+        // Passwords must match
+        // Trim any trailing space before comparing
+        // Should not matter because of trim on change
+        (password.trim() === passwordRepeat.trim());
+
     const onSubmit = () => {
-        onUpdate && onUpdate(password);
+        canSubmit && !!onUpdate && onUpdate(password.trim());
     };
 
     const togglePassword = () => {
         setShowPassword(!showPassword);
     };
-
-    const canSubmit = !!password && password === passwordRepeat;
 
     return (
         <Fragment>
@@ -164,6 +190,9 @@ const PasswordUpdateForm: FunctionComponent<{
                 <li>
                     <Typography variant="caption">Must contain symbol characters</Typography>
                 </li>
+                <li>
+                    <Typography variant="caption">Must not include spaces</Typography>
+                </li>
             </ul>
             <FormControl error={!!error} fullWidth>
                 <TextField
@@ -175,7 +204,14 @@ const PasswordUpdateForm: FunctionComponent<{
                     variant="standard"
                     margin="normal"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => setPassword(
+                        // Cognito allows passwords to include an interior space,
+                        // but that is confusing and causes issues with temporarily allowing trailing spaces.
+                        // We will decide to not allow creation of passwords including an interior space.
+                        // Continuously trim input so spaces are not added,
+                        // then we will separately validate lack of spaces to handle the copy-paste scenario.
+                        e.target.value.trim()
+                    )}
                     InputLabelProps={{
                         shrink: true,
                     }}
@@ -190,17 +226,25 @@ const PasswordUpdateForm: FunctionComponent<{
                             </InputAdornment>
                         ),
                     }}
+                    error={!validPassword}
                 />
                 <TextField
-                    label="Password-retype"
-                    placeholder="Retype password"
+                    label="Confirm Password"
+                    placeholder="Confirm password"
                     type="password"
                     fullWidth
                     required
                     variant="standard"
                     margin="normal"
                     value={passwordRepeat}
-                    onChange={(e) => setPasswordRepeat(e.target.value)}
+                    onChange={(e) => setPasswordRepeat(
+                        // Cognito allows passwords to include an interior space,
+                        // but that is confusing and causes issues with temporarily allowing trailing spaces.
+                        // We will decide to not allow creation of passwords including an interior space.
+                        // Continuously trim input so spaces are not added,
+                        // then we will separately validate lack of spaces to handle the copy-paste scenario.
+                        e.target.value.trim()
+                    )}
                     InputLabelProps={{
                         shrink: true,
                     }}

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -59,7 +59,7 @@ const LoginForm: FunctionComponent<{
                     margin="normal"
                     variant="standard"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(e) => setEmail(e.target.value.replace(/\s/g, ''))}
                     InputLabelProps={{
                         shrink: true,
                     }}
@@ -78,7 +78,7 @@ const LoginForm: FunctionComponent<{
                     variant="standard"
                     margin="normal"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => setPassword(e.target.value.replace(/\s/g, ''))}
                     InputLabelProps={{
                         shrink: true,
                     }}

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -59,7 +59,10 @@ const LoginForm: FunctionComponent<{
                     margin="normal"
                     variant="standard"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value.replace(/\s/g, ''))}
+                    onChange={(e) => setEmail(
+                        // Username cannot include whitespace.
+                        e.target.value.replace(/\s/g, '')
+                    )}
                     InputLabelProps={{
                         shrink: true,
                     }}
@@ -78,7 +81,11 @@ const LoginForm: FunctionComponent<{
                     variant="standard"
                     margin="normal"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value.replace(/\s/g, ''))}
+                    onChange={(e) => setPassword(
+                        // Password can include an interior space,
+                        // but cannot include any other whitespace.
+                        e.target.value.replace(/[\t\r\n\f]/g, '').trim()
+                    )}
                     InputLabelProps={{
                         shrink: true,
                     }}

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -88,7 +88,7 @@ const LoginForm: FunctionComponent<{
                         // We must allow a right-side space for now,
                         // as additional typing could turn it into an interior space.
                         // We will then trim the string whenever extracting it from this field.
-                        e.target.value.replace(/[\t\r\n\f]/g, '').trimLeft()
+                        e.target.value.replace(/[\t\r\n\f]/g, '').trimStart()
                     )}
                     InputLabelProps={{
                         shrink: true,


### PR DESCRIPTION
Adds error handling around password creation and entry.

Accidental spaces when copy-pasting passwords were causing login failures. Passwords are now automatically trimmed during both creation and entry. Entry continues to allow an interior space as part of a password, but creation now does not.

Password creation now gives minimal feedback on password criteria.

<img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/889a692f-6895-4d63-bb1a-f4445ba50cd3">
<img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/187114a6-fe16-4a47-8a30-6ce69264221a">
<img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/469585f8-6d57-4108-b783-4d1516f1f043">
<img width="150" alt="image" src="https://github.com/uwscope/scope-web/assets/2163573/46cb70f8-5657-4f11-b9d8-c07e5f22ba09">
