### PR TITLE
Highlight Overdue Follow-Up, Add "As Needed" Follow-Up Schedule

### DIFF
--- a/scope_shared/scope/enums.py
+++ b/scope_shared/scope/enums.py
@@ -79,6 +79,7 @@ class FollowupSchedule(Enum):
     FourWeeks = "4-week follow-up"
     SixWeeks = "6-week follow-up"
     EightWeeks = "8-week follow-up"
+    AsNeeded = "As needed"
 
 
 class DiscussionFlag(Enum):

--- a/scope_shared/scope/schemas/utils/enums.json
+++ b/scope_shared/scope/schemas/utils/enums.json
@@ -248,7 +248,8 @@
         "3-week follow-up",
         "4-week follow-up",
         "6-week follow-up",
-        "8-week follow-up"
+        "8-week follow-up",
+        "As needed"
       ]
     },
     "gender": {

--- a/server_flask/enums.py
+++ b/server_flask/enums.py
@@ -73,6 +73,7 @@ class FollowupSchedule(Enum):
     FourWeeks = "4-week follow-up"
     SixWeeks = "6-week follow-up"
     EightWeeks = "8-week follow-up"
+    AsNeeded = "As needed"
 
 
 class DiscussionFlag(Enum):

--- a/web_registry/src/components/PatientDetail/PatientProfileDialog.tsx
+++ b/web_registry/src/components/PatientDetail/PatientProfileDialog.tsx
@@ -5,6 +5,7 @@ import { action } from "mobx";
 import { observer, useLocalObservable } from "mobx-react";
 import {
   clinicCodeValues,
+  DepressionTreatmentStatus,
   depressionTreatmentStatusValues,
   followupScheduleValues,
   patientEthnicityValues,
@@ -28,6 +29,9 @@ import StatefulDialog from "src/components/common/StatefulDialog";
 interface IEditPatientProfileContentProps extends Partial<IPatientProfile> {
   availableCareManagerNames: string[];
   onCareManagerChange: (providerName: string) => void;
+  onDepressionTreatmentStatusChange: (
+    depressionTreatmentStatus?: DepressionTreatmentStatus,
+  ) => void;
   onValueChange: (key: string, value: any) => void;
 }
 
@@ -53,6 +57,7 @@ const EditPatientProfileContent: FunctionComponent<
     enrollmentDate,
     onValueChange,
     onCareManagerChange,
+    onDepressionTreatmentStatusChange,
   } = props;
 
   const sortedAvailableCareManagerNames = sortStringsCaseInsensitive(
@@ -143,12 +148,15 @@ const EditPatientProfileContent: FunctionComponent<
         options={sortedAvailableCareManagerNames}
         onChange={(text) => onCareManagerChange(text as string)}
       />
-      {getDropdownField(
-        "Treatment Status",
-        depressionTreatmentStatus || "",
-        depressionTreatmentStatusValues,
-        "depressionTreatmentStatus",
-      )}
+      <GridDropdownField
+        editable
+        label={"Treatment Status"}
+        value={depressionTreatmentStatus || ""}
+        options={depressionTreatmentStatusValues}
+        onChange={(text) =>
+          onDepressionTreatmentStatusChange(text as DepressionTreatmentStatus)
+        }
+      />
       {getDropdownField(
         "Follow-Up Schedule",
         followupSchedule || "",
@@ -244,6 +252,18 @@ export const EditPatientProfileDialog: FunctionComponent<IEditPatientProfileDial
       }
     });
 
+    const onDepressionTreatmentStatusChange = action(
+      (depressionTreatmentStatus?: DepressionTreatmentStatus) => {
+        state.depressionTreatmentStatus = depressionTreatmentStatus;
+
+        if (depressionTreatmentStatus) {
+          if (["D/C"].includes(depressionTreatmentStatus)) {
+            state.followupSchedule = "As needed";
+          }
+        }
+      },
+    );
+
     const availableCareManagerNames = careManagers.map((c) => c.name);
 
     return (
@@ -258,6 +278,9 @@ export const EditPatientProfileDialog: FunctionComponent<IEditPatientProfileDial
             availableCareManagerNames={availableCareManagerNames}
             onValueChange={onValueChange}
             onCareManagerChange={onCareManagerChange}
+            onDepressionTreatmentStatusChange={
+              onDepressionTreatmentStatusChange
+            }
           />
         }
         handleCancel={onClose}

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -20,6 +20,7 @@ import {
 import {
   addWeeks,
   compareAsc,
+  differenceInDays,
   differenceInMonths,
   differenceInWeeks,
 } from "date-fns";
@@ -228,6 +229,20 @@ const renderChangeCell = (props: GridCellParams) => (
   <ChangeCell change={props.value as number}>{`${props.value}%`}</ChangeCell>
 );
 
+const renderCellFollowUpDue = (props: GridCellParams) => {
+  const overdue = props.row["nextSessionOverdue"] as boolean;
+
+  if (overdue) {
+    return (
+      <HiglightedCell scoreColorKey="warning">
+        {props.formattedValue}
+      </HiglightedCell>
+    );
+  } else {
+    return props.formattedValue;
+  }
+};
+
 const renderCellLastCaseReview = (props: GridCellParams) => {
   const overdue = props.row["recentCaseReviewOverdue"] as boolean;
 
@@ -413,7 +428,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
       },
       {
         field: "nextSessionDue",
-        headerName: "Follow-up Due",
+        headerName: "Follow-Up Due",
         width: 85,
         renderHeader,
         align: "center",
@@ -421,6 +436,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
         filterable: false,
         sortComparator: nullUndefinedComparator("last", gridDateComparator),
         valueFormatter: nullUndefinedFormatter(dateFormatter),
+        renderCell: renderCellFollowUpDue,
       },
       {
         field: "totalSessions",
@@ -637,6 +653,9 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
           // Nothing else can be overdue
           return false;
         })();
+        const nextSessionOverdue =
+          nextSessionDueDate &&
+          differenceInDays(todayDateUtc, nextSessionDueDate) >= 1;
         const initialAtRisk =
           phq9Entries &&
           phq9Entries.length > 0 &&
@@ -687,6 +706,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
           // Not rendered, used by other columns
           //
           recentCaseReviewOverdue: recentReviewOverdue,
+          nextSessionOverdue: nextSessionOverdue,
           initialAtRisk: initialAtRisk,
           recentAtRisk: recentAtRisk,
           enrollmentDateHighlight: enrollmentDateHighlight,

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -26,7 +26,7 @@ import {
 } from "date-fns";
 import { observer } from "mobx-react";
 import { DiscussionFlags } from "shared/enums";
-import { formatDateOnly, getFollowupWeeks, toUTCDateOnly } from "shared/time";
+import { formatDateOnly, getFollowUpWeeks, toUTCDateOnly } from "shared/time";
 import { Table } from "src/components/common/Table";
 import { IPatientStore } from "src/stores/PatientStore";
 import {
@@ -567,10 +567,10 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
         const recentSessionDate = p.latestSession?.date;
         const recentReviewDate = p.latestCaseReview?.date;
         const nextSessionDueDate =
-          recentSessionDate && p.profile.followupSchedule
+          recentSessionDate && p.profile.followupSchedule && p.profile.followupSchedule != "As needed"
             ? addWeeks(
                 recentSessionDate,
-                getFollowupWeeks(p.profile.followupSchedule),
+                getFollowUpWeeks(p.profile.followupSchedule),
               )
             : undefined;
 

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -567,7 +567,9 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
         const recentSessionDate = p.latestSession?.date;
         const recentReviewDate = p.latestCaseReview?.date;
         const nextSessionDueDate =
-          recentSessionDate && p.profile.followupSchedule && p.profile.followupSchedule != "As needed"
+          recentSessionDate &&
+          p.profile.followupSchedule &&
+          p.profile.followupSchedule != "As needed"
             ? addWeeks(
                 recentSessionDate,
                 getFollowUpWeeks(p.profile.followupSchedule),

--- a/web_shared/enums.ts
+++ b/web_shared/enums.ts
@@ -75,6 +75,7 @@ export const followupScheduleValues = [
   "4-week follow-up",
   "6-week follow-up",
   "8-week follow-up",
+  "As needed"
 ] as const;
 export type FollowupSchedule = (typeof followupScheduleValues)[number];
 

--- a/web_shared/enums.ts
+++ b/web_shared/enums.ts
@@ -75,7 +75,7 @@ export const followupScheduleValues = [
   "4-week follow-up",
   "6-week follow-up",
   "8-week follow-up",
-  "As needed"
+  "As needed",
 ] as const;
 export type FollowupSchedule = (typeof followupScheduleValues)[number];
 

--- a/web_shared/time.ts
+++ b/web_shared/time.ts
@@ -106,7 +106,7 @@ export const getDayOfWeek = (date: Date): DayOfWeek => {
   return daysOfWeekValues[(date.getDay() + 7 - 1) % 7];
 };
 
-export const getFollowupWeeks = (schedule: FollowupSchedule) => {
+export const getFollowUpWeeks = (schedule: Exclude<FollowupSchedule, "As needed">) => {
   switch (schedule) {
     case "1-week follow-up":
       return 1;
@@ -120,8 +120,6 @@ export const getFollowupWeeks = (schedule: FollowupSchedule) => {
       return 6;
     case "8-week follow-up":
       return 8;
-    default:
-      return 0;
   }
 };
 

--- a/web_shared/time.ts
+++ b/web_shared/time.ts
@@ -106,7 +106,9 @@ export const getDayOfWeek = (date: Date): DayOfWeek => {
   return daysOfWeekValues[(date.getDay() + 7 - 1) % 7];
 };
 
-export const getFollowUpWeeks = (schedule: Exclude<FollowupSchedule, "As needed">) => {
+export const getFollowUpWeeks = (
+  schedule: Exclude<FollowupSchedule, "As needed">,
+) => {
   switch (schedule) {
     case "1-week follow-up":
       return 1;


### PR DESCRIPTION
By request, highlight any "Follow-Up Due" in caseload overview which is overdue.

- A follow-up is overdue and highlighted in yellow whenever the displayed follow-up due date is in the past.

- A new "As needed" follow-up schedule has been introduced. If selected, no follow-up due date is calculated.

- When treatment status is changed to "D/C", follow-up schedule automatically changes to "As Needed".

![Screenshot 2024-05-28 at 05-54-39 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/b9ea3e6c-dee8-4e8f-999b-0b697e4bb91e)
