### PR TITLE
Consistently Sort Sessions by Date

### DIFF
--- a/web_registry/src/components/PatientDetail/BAChecklist.tsx
+++ b/web_registry/src/components/PatientDetail/BAChecklist.tsx
@@ -12,7 +12,6 @@ import {
   TableHead,
   TableRow,
 } from "@mui/material";
-import { compareAsc } from "date-fns";
 import { observer } from "mobx-react";
 import {
   BehavioralActivationChecklistItem,
@@ -31,9 +30,7 @@ export const BAChecklist: FunctionComponent = observer(() => {
   const currentPatient = usePatient();
 
   const baCompletion: { [key: string]: Date | undefined } = {};
-  currentPatient?.sessions
-    .slice()
-    .sort((a, b) => compareAsc(a.date, b.date))
+  currentPatient?.sessionsSortedByDate
     .map((s) => s as ISession)
     .forEach((s) => {
       Object.keys(s.behavioralActivationChecklist).forEach((key) => {

--- a/web_registry/src/components/PatientDetail/PatientCardExtended.tsx
+++ b/web_registry/src/components/PatientDetail/PatientCardExtended.tsx
@@ -37,14 +37,13 @@ export const PatientCardExtended: FunctionComponent = observer((_) => {
   });
 
   const sessionCount = patient.sessionsSortedByDate.length;
-  const firstSession =
+  const firstSessionDate =
     sessionCount > 0
       ? formatDateOnly(patient.sessionsSortedByDate[0].date, "MM/dd/yyyy")
       : "--";
-  const lastSession =
-    sessionCount > 0
-      ? formatDateOnly(patient.sessionsSortedByDate[sessionCount - 1].date, "MM/dd/yyyy")
-      : "--";
+  const lastSessionDate = patient.latestSession
+    ? formatDateOnly(patient.latestSession.date, "MM/dd/yyyy")
+    : "--";
 
   const flaggedForDiscussion =
     !!profile.discussionFlag?.["Flag for discussion"];
@@ -55,8 +54,8 @@ export const PatientCardExtended: FunctionComponent = observer((_) => {
       {sessionCount > 0 ? (
         <div>
           <LabeledField label="Session #" value={sessionCount} />
-          <LabeledField label="First Session" value={firstSession} />
-          <LabeledField label="Last Session" value={lastSession} />
+          <LabeledField label="First Session" value={firstSessionDate} />
+          <LabeledField label="Last Session" value={lastSessionDate} />
           <br />
         </div>
       ) : null}

--- a/web_registry/src/components/PatientDetail/PatientCardExtended.tsx
+++ b/web_registry/src/components/PatientDetail/PatientCardExtended.tsx
@@ -36,14 +36,14 @@ export const PatientCardExtended: FunctionComponent = observer((_) => {
     state.open = false;
   });
 
-  const sessionCount = patient.sessions.length;
+  const sessionCount = patient.sessionsSortedByDate.length;
   const firstSession =
     sessionCount > 0
-      ? formatDateOnly(patient.sessions[0].date, "MM/dd/yyyy")
+      ? formatDateOnly(patient.sessionsSortedByDate[0].date, "MM/dd/yyyy")
       : "--";
   const lastSession =
     sessionCount > 0
-      ? formatDateOnly(patient.sessions[sessionCount - 1].date, "MM/dd/yyyy")
+      ? formatDateOnly(patient.sessionsSortedByDate[sessionCount - 1].date, "MM/dd/yyyy")
       : "--";
 
   const flaggedForDiscussion =

--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -544,7 +544,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
         log.totalScore || getAssessmentScoreFromPointValues(log.pointValues),
     }));
 
-  const sessionDates = currentPatient.sessions
+  const sessionDates = currentPatient.sessionsSortedByDate
     .filter((s) => !!s.sessionId)
     .map((s) => ({
       date: s.date,

--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -430,9 +430,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
   });
 
   const handleEditSession = action((sessionId: string) => {
-    const session = currentPatient.sessions.find(
-      (s) => s.sessionId == sessionId,
-    );
+    const session = currentPatient.getSessionById(sessionId);
 
     state.session = { ...getDefaultSession(), ...session };
     state.open = true;

--- a/web_registry/src/components/PatientDetail/TreatmentInfo.tsx
+++ b/web_registry/src/components/PatientDetail/TreatmentInfo.tsx
@@ -47,7 +47,7 @@ export const TreatmentInfo: FunctionComponent = observer(() => {
     Other: false,
   };
 
-  currentPatient.sessions.forEach((s) => {
+  currentPatient.sessionsSortedByDate.forEach((s) => {
     Object.keys(s.behavioralStrategyChecklist).forEach((k) => {
       if (
         !!s.behavioralStrategyChecklist[k as BehavioralStrategyChecklistItem]

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -522,10 +522,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
           p.sessionsSortedByDate?.length > 0
             ? p.sessionsSortedByDate[0].date
             : undefined;
-        const recentSessionDate =
-          p.sessionsSortedByDate?.length > 0
-            ? p.sessionsSortedByDate[p.sessionsSortedByDate.length - 1].date
-            : undefined;
+        const recentSessionDate = p.latestSession?.date;
         const recentReviewDate =
           p.caseReviews?.length > 0
             ? p.caseReviews[p.caseReviews.length - 1].date

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -519,7 +519,9 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
     const data = patients
       .map((p) => {
         const initialSessionDate =
-          p.sessionsSortedByDate?.length > 0 ? p.sessionsSortedByDate[0].date : undefined;
+          p.sessionsSortedByDate?.length > 0
+            ? p.sessionsSortedByDate[0].date
+            : undefined;
         const recentSessionDate =
           p.sessionsSortedByDate?.length > 0
             ? p.sessionsSortedByDate[p.sessionsSortedByDate.length - 1].date
@@ -537,7 +539,9 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
             : undefined;
 
         const totalSessionsCount =
-          p.sessionsSortedByDate && p.sessionsSortedByDate.length > 0 ? p.sessionsSortedByDate.length : undefined;
+          p.sessionsSortedByDate && p.sessionsSortedByDate.length > 0
+            ? p.sessionsSortedByDate.length
+            : undefined;
         const treatmentWeeksCount =
           initialSessionDate && recentSessionDate
             ? differenceInWeeks(recentSessionDate, initialSessionDate) + 1

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -519,10 +519,10 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
     const data = patients
       .map((p) => {
         const initialSessionDate =
-          p.sessions?.length > 0 ? p.sessions[0].date : undefined;
+          p.sessionsSortedByDate?.length > 0 ? p.sessionsSortedByDate[0].date : undefined;
         const recentSessionDate =
-          p.sessions?.length > 0
-            ? p.sessions[p.sessions.length - 1].date
+          p.sessionsSortedByDate?.length > 0
+            ? p.sessionsSortedByDate[p.sessionsSortedByDate.length - 1].date
             : undefined;
         const recentReviewDate =
           p.caseReviews?.length > 0
@@ -537,7 +537,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
             : undefined;
 
         const totalSessionsCount =
-          p.sessions && p.sessions.length > 0 ? p.sessions.length : undefined;
+          p.sessionsSortedByDate && p.sessionsSortedByDate.length > 0 ? p.sessionsSortedByDate.length : undefined;
         const treatmentWeeksCount =
           initialSessionDate && recentSessionDate
             ? differenceInWeeks(recentSessionDate, initialSessionDate) + 1

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -289,8 +289,8 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get latestSession() {
-    if (this.sessions.length > 0) {
-      return this.sessions[this.sessions.length - 1];
+    if (this.sessionsSortedByDate.length > 0) {
+      return this.sessionsSortedByDate[this.sessionsSortedByDate.length - 1];
     }
 
     return undefined;

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -13,6 +13,7 @@ import {
   IPatientService,
 } from "shared/patientService";
 import { IPromiseQueryState, PromiseQuery } from "shared/promiseQuery";
+import { sortSessionsByDate } from "shared/sorting";
 import {
   getLoadAndLogQuery,
   onArrayConflict,
@@ -63,6 +64,9 @@ export interface IPatientStore extends IPatient {
   readonly loadSessionsState: IPromiseQueryState;
   readonly loadValuesState: IPromiseQueryState;
   readonly loadValuesInventoryState: IPromiseQueryState;
+
+  // Sorted properties
+  readonly sessionsSortedByDate: ISession[];
 
   // Helpers
   getActivitiesByLifeAreaId: (lifeAreaId: string) => IActivity[];
@@ -319,6 +323,10 @@ export class PatientStore implements IPatientStore {
 
   @computed get sessions() {
     return this.loadSessionsQuery.value || [];
+  }
+
+  @computed get sessionsSortedByDate() {
+    return sortSessionsByDate(this.sessions.slice());
   }
 
   @computed public get values() {

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -407,7 +407,6 @@ export class PatientStore implements IPatientStore {
   }
 
   // Helpers
-  @action.bound
   public getActivitiesByLifeAreaId(lifeAreaId: string) {
     return this.activities.filter((a) => {
       if (!a.valueId) {
@@ -423,7 +422,6 @@ export class PatientStore implements IPatientStore {
     });
   }
 
-  @action.bound
   public getActivitiesByValueId(valueId: string) {
     return this.activities.filter((a) => {
       if (!a.valueId) {
@@ -434,14 +432,13 @@ export class PatientStore implements IPatientStore {
     });
   }
 
-  @action.bound
   public getActivitiesWithoutValueId() {
     return this.activities.filter((a) => {
       return !a.valueId;
     });
   }
 
-  @action.bound getValueById(valueId: string) {
+  public getValueById(valueId: string) {
     return this.values.find((v) => v.valueId == valueId);
   }
 

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -72,6 +72,7 @@ export interface IPatientStore extends IPatient {
   getActivitiesByLifeAreaId: (lifeAreaId: string) => IActivity[];
   getActivitiesByValueId: (valueId: string) => IActivity[];
   getActivitiesWithoutValueId: () => IActivity[];
+  getSessionById: (sessionId: string) => ISession | undefined;
   getValueById: (valueId: string) => IValue | undefined;
 
   // Data load/save
@@ -436,6 +437,10 @@ export class PatientStore implements IPatientStore {
     return this.activities.filter((a) => {
       return !a.valueId;
     });
+  }
+
+  public getSessionById(sessionId: string) {
+    return this.sessions.find((v) => v.sessionId == sessionId);
   }
 
   public getValueById(valueId: string) {

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -836,9 +836,9 @@ export class PatientStore implements IPatientStore {
         ),
       })
       .then((updatedSession) => {
-        const existing = this.sessions.find(
-          (s) => s.sessionId == updatedSession.sessionId,
-        );
+        const existing = !!updatedSession.sessionId
+          ? this.getSessionById(updatedSession.sessionId)
+          : undefined;
         logger.assert(!!existing, "Session not found when expected");
 
         if (!!existing) {

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -1,6 +1,6 @@
 import { compareAsc } from "date-fns";
 import { toLocalDateTime } from "shared/time";
-import { IActivity, IActivitySchedule } from "shared/types";
+import { IActivity, IActivitySchedule, ISession } from "shared/types";
 
 export const compareActivityByName: (
   compareA: IActivity,
@@ -20,6 +20,13 @@ export const compareActivityScheduleByDateAndTime: (
   const compareDateB = toLocalDateTime(compareB.date, compareB.timeOfDay);
 
   return compareAsc(compareDateA, compareDateB);
+};
+
+export const compareSessionsByDate: (
+  compareA: ISession,
+  compareB: ISession,
+) => number = function (compareA: ISession, compareB: ISession): number {
+  return compareAsc(compareA.date, compareB.date);
 };
 
 export const compareStringCaseInsensitive: (
@@ -44,6 +51,11 @@ export const sortActivitySchedulesByDateAndTime: (
 ): IActivitySchedule[] {
   return activitySchedules.slice().sort(compareActivityScheduleByDateAndTime);
 };
+
+export const sortSessionsByDate: (sessions: ISession[]) => ISession[] =
+  function (sessions: ISession[]): ISession[] {
+    return sessions.slice().sort(compareSessionsByDate);
+  };
 
 export const sortStringsCaseInsensitive: (strings: string[]) => string[] =
   function (strings: string[]): string[] {


### PR DESCRIPTION
The underlying order of sessions objects has been based on `_id`, which in turn corresponds to the order in which documents were added to the database. This often appears to also be sorted by date, but that correlation breaks down if a session is edited. A new document will be created for the edit, which will appear most recent regardless of its underlying date.

This was showing up as several weird behaviors:

- Incorrect and even negative values in the Caseload:

  ![Screenshot 2024-03-13 at 07-19-17 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/bec33715-d37b-4926-a280-e6d2c061eb2a)

- Incorrect dates in the patient summary:

  ![Screenshot 2024-03-13 at 06-07-23 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/660b8bbd-b20f-4171-bf29-2c0ffc4cd92a)

- Incorrect dates and potentially incorrect data in treatment summary:

   ![Screenshot 2024-03-13 at 07-15-04 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/1d5d7076-df5a-4fdb-b2ec-d9dda45788eb)


This update fixes all of these issues, consistently sorting sessions by date before using them.