### PR TITLE
Create an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.{ts, tsx}]
+indent_size = 2


### PR DESCRIPTION
With black and prettier now formatting our code, a simple `.editorconfig` would be consistent.

Resolves #3.