### PR TITLE
Update Cancel Assignment Text and Icons

### DIFF
--- a/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
+++ b/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
 import AssignmentIcon from "@mui/icons-material/Assignment";
-import ClearIcon from "@mui/icons-material/Clear";
+import ContentPasteOffOutlinedIcon from "@mui/icons-material/ContentPasteOffOutlined";
 import SettingsIcon from "@mui/icons-material/Settings";
 import {
   Button,
@@ -338,7 +338,7 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
         actionButtons={[
           assessment.assigned
             ? ({
-                icon: <ClearIcon />,
+                icon: <ContentPasteOffOutlinedIcon />,
                 text: getString("patient_progress_assessment_cancel_button"),
                 onClick: () =>
                   currentPatient?.cancelAssessment(assessment.assessmentId),

--- a/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
+++ b/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
-import AssignmentIcon from "@mui/icons-material/Assignment";
+import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined";
 import ContentPasteOffOutlinedIcon from "@mui/icons-material/ContentPasteOffOutlined";
 import SettingsIcon from "@mui/icons-material/Settings";
 import {
@@ -344,7 +344,7 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
                   currentPatient?.cancelAssessment(assessment.assessmentId),
               } as IActionButton)
             : ({
-                icon: <AssignmentIcon />,
+                icon: <AssignmentOutlinedIcon />,
                 text: getString("patient_progress_assessment_assign_button"),
                 onClick: () =>
                   currentPatient?.assignAssessment(assessment.assessmentId),

--- a/web_registry/src/components/PatientDetail/MedicationProgress.tsx
+++ b/web_registry/src/components/PatientDetail/MedicationProgress.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 
-import AssignmentIcon from "@mui/icons-material/Assignment";
-import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
+import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined";
+import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
 import SettingsIcon from "@mui/icons-material/Settings";
 import {
   Button,
@@ -145,9 +145,9 @@ export const MedicationProgress: FunctionComponent<IMedicationProgressProps> =
         actionButtons={[
           {
             icon: assessment.assigned ? (
-              <AssignmentTurnedInIcon />
+              <AssignmentTurnedInOutlinedIcon />
             ) : (
-              <AssignmentIcon />
+              <AssignmentOutlinedIcon />
             ),
             text: assessment.assigned
               ? getString("patient_progress_assessment_assigned_button")

--- a/web_registry/src/components/PatientDetail/SafetyPlan.tsx
+++ b/web_registry/src/components/PatientDetail/SafetyPlan.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 
-import AssignmentIcon from "@mui/icons-material/Assignment";
-import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
+import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined";
+import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
 import { Grid } from "@mui/material";
 import { format } from "date-fns";
 import { observer } from "mobx-react-lite";
@@ -58,7 +58,11 @@ export const SafetyPlan: FunctionComponent = observer(() => {
       error={currentPatient?.loadSafetyPlanState.error}
       actionButtons={[
         {
-          icon: assigned ? <AssignmentTurnedInIcon /> : <AssignmentIcon />,
+          icon: assigned ? (
+            <AssignmentTurnedInOutlinedIcon />
+          ) : (
+            <AssignmentOutlinedIcon />
+          ),
           text: assigned
             ? getString("patient_safety_plan_assigned_button")
             : getString("patient_safety_plan_assign_button"),

--- a/web_registry/src/components/PatientDetail/ValuesInventory.tsx
+++ b/web_registry/src/components/PatientDetail/ValuesInventory.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 
-import AssignmentIcon from "@mui/icons-material/Assignment";
-import AssignmentTurnedInIcon from "@mui/icons-material/AssignmentTurnedIn";
+import AssignmentOutlinedIcon from "@mui/icons-material/AssignmentOutlined";
+import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
 import {
   Grid,
   Table,
@@ -126,7 +126,11 @@ export const ValuesInventory: FunctionComponent = observer(() => {
       error={currentPatient?.loadValuesInventoryState.error}
       actionButtons={[
         {
-          icon: assigned ? <AssignmentTurnedInIcon /> : <AssignmentIcon />,
+          icon: assigned ? (
+            <AssignmentTurnedInOutlinedIcon />
+          ) : (
+            <AssignmentOutlinedIcon />
+          ),
           text: assigned
             ? getString("patient_values_inventory_assigned_button")
             : getString("patient_values_inventory_assign_button"),

--- a/web_registry/src/services/strings.ts
+++ b/web_registry/src/services/strings.ts
@@ -34,7 +34,7 @@ const _strings = {
   patient_progress_assessment_assign_button: "Assign",
   patient_progress_assessment_assigned_button: "Assigned",
   patient_progress_assessment_assigned_date: "Assigned on",
-  patient_progress_assessment_cancel_button: "Cancel",
+  patient_progress_assessment_cancel_button: "Cancel Assignment",
   patient_progress_assessment_header_date: "Date",
   patient_progress_assessment_header_comment: "Note",
   patient_progress_assessment_action_add: "Add Record",


### PR DESCRIPTION
In discussion of #417, we decided to go with "Cancel Assignment".

We also decided the [ContentPasteOff](https://mui.com/material-ui/material-icons/?query=contentpas&selected=ContentPasteOff) icon would work well.

In making that change, found that the default "Filled" version of the icon is not filled. It is identical to "Outlined". The result looked bad next to other icons which are "Filled", so I adjusted all of them to "Outlined".

Assign / Cancel Assignment:
![Screenshot 2024-03-16 at 06-56-29 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/cac1cf63-6d51-4823-a9b2-64087e72847f)

Assign / Reassign:
![Screenshot 2024-03-16 at 06-57-02 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/3e56f357-9a7e-4198-98fe-499eec515642)  ![Screenshot 2024-03-16 at 06-56-52 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/a53d25b8-65db-4044-bf1e-2ac040f7f1d2)

