### PR TITLE
Consistently Sort Case Reviews by Date

### DIFF
--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
 import { Grid } from "@mui/material";
-import { compareAsc } from "date-fns";
 import { action, runInAction } from "mobx";
 import { observer, useLocalObservable } from "mobx-react";
 import {
@@ -16,13 +15,7 @@ import {
   sessionTypeValues,
 } from "shared/enums";
 import { clearTime, toLocalDateOnly, toUTCDateOnly } from "shared/time";
-import {
-  ICaseReview,
-  IReferralStatus,
-  ISession,
-  ISessionOrCaseReview,
-  KeyedMap,
-} from "shared/types";
+import { ICaseReview, IReferralStatus, ISession, KeyedMap } from "shared/types";
 import ActionPanel, { IActionButton } from "src/components/common/ActionPanel";
 import {
   GridDateField,
@@ -442,9 +435,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
   });
 
   const handleEditReview = action((caseReviewId: string) => {
-    const review = currentPatient.caseReviews.find(
-      (s) => s.caseReviewId == caseReviewId,
-    );
+    const review = currentPatient.getCaseReviewById(caseReviewId);
 
     state.review = { ...getDefaultReview(), ...review };
     state.open = true;
@@ -517,15 +508,6 @@ export const SessionInfo: FunctionComponent = observer(() => {
     });
   });
 
-  const sortedSessionOrReviews = (
-    currentPatient.sessions as ISessionOrCaseReview[]
-  )
-    .concat(currentPatient.caseReviews)
-    .slice()
-    .sort((a, b) =>
-      compareAsc(a.date, b.date),
-    );
-
   const phqScores = currentPatient.assessmentLogs
     .filter((log) => log.assessmentId == "phq-9")
     .map((log) => ({
@@ -549,7 +531,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
       id: s.sessionId as string,
     }));
 
-  const reviewDates = currentPatient.caseReviews
+  const reviewDates = currentPatient.caseReviewsSortedByDate
     .filter((r) => !!r.caseReviewId)
     .map((r) => ({
       date: r.date,
@@ -590,12 +572,12 @@ export const SessionInfo: FunctionComponent = observer(() => {
     >
       <Grid container alignItems="stretch">
         <SessionReviewTable
-          sessionOrReviews={sortedSessionOrReviews}
+          sessionOrReviews={currentPatient.caseReviewsOrSessionsSortedByDate}
           onReviewClick={handleEditReview}
           onSessionClick={handleEditSession}
         />
         {currentPatient.assessmentLogs.length > 0 &&
-          sortedSessionOrReviews.length > 0 && (
+          currentPatient.caseReviewsOrSessionsSortedByDate.length > 0 && (
             <Grid item xs={12}>
               <SessionProgressVis
                 phqScores={phqScores}

--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
 import { Grid } from "@mui/material";
-import { compareAsc, compareDesc } from "date-fns";
+import { compareAsc } from "date-fns";
 import { action, runInAction } from "mobx";
 import { observer, useLocalObservable } from "mobx-react";
 import {
@@ -85,7 +85,6 @@ const getDefaultReview = () =>
 interface IState {
   open: boolean;
   isNew: boolean;
-  dateAsc: boolean;
   entryType: EntryType;
   session: ISession;
   review: ICaseReview;
@@ -97,7 +96,6 @@ const getDefaultState = () =>
   ({
     open: false,
     isNew: false,
-    dateAsc: false,
     session: getDefaultSession(),
     review: getDefaultReview(),
     entryType: "Session",
@@ -525,7 +523,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
     .concat(currentPatient.caseReviews)
     .slice()
     .sort((a, b) =>
-      state.dateAsc ? compareAsc(a.date, b.date) : compareDesc(a.date, b.date),
+      compareAsc(a.date, b.date),
     );
 
   const phqScores = currentPatient.assessmentLogs

--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -523,10 +523,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
             ? p.sessionsSortedByDate[0].date
             : undefined;
         const recentSessionDate = p.latestSession?.date;
-        const recentReviewDate =
-          p.caseReviews?.length > 0
-            ? p.caseReviews[p.caseReviews.length - 1].date
-            : undefined;
+        const recentReviewDate = p.latestCaseReview?.date;
         const nextSessionDueDate =
           recentSessionDate && p.profile.followupSchedule
             ? addWeeks(

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -765,9 +765,9 @@ export class PatientStore implements IPatientStore {
         },
       })
       .then((updatedReview) => {
-        const existing = this.caseReviews.find(
-          (r) => r.caseReviewId == updatedReview.caseReviewId,
-        );
+        const existing = !!updatedReview.caseReviewId
+          ? this.getCaseReviewById(updatedReview.caseReviewId)
+          : undefined;
         logger.assert(!!existing, "Case review not found when expected");
 
         if (!!existing) {

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -31,6 +31,13 @@ export const compareCaseReviewsByDate: (
   return compareAsc(compareA.date, compareB.date);
 };
 
+export const compareCaseReviewsOrSessionsByDate: (
+  compareA: ICaseReview | ISession,
+  compareB: ICaseReview | ISession,
+) => number = function (compareA, compareB): number {
+  return compareAsc(compareA.date, compareB.date);
+};
+
 export const compareSessionsByDate: (
   compareA: ISession,
   compareB: ISession,
@@ -63,6 +70,12 @@ export const sortCaseReviewsByDate: (
   caseReviews: ICaseReview[],
 ) => ICaseReview[] = function (caseReviews) {
   return caseReviews.slice().sort(compareCaseReviewsByDate);
+};
+
+export const sortCaseReviewsOrSessionsByDate: (
+  caseReviewsOrSessions: (ICaseReview | ISession)[],
+) => (ICaseReview | ISession)[] = function (caseReviewsOrSessions) {
+  return caseReviewsOrSessions.slice().sort(compareCaseReviewsOrSessionsByDate);
 };
 
 export const sortSessionsByDate: (sessions: ISession[]) => ISession[] =

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -1,6 +1,11 @@
 import { compareAsc } from "date-fns";
 import { toLocalDateTime } from "shared/time";
-import { IActivity, IActivitySchedule, ISession } from "shared/types";
+import {
+  IActivity,
+  IActivitySchedule,
+  ICaseReview,
+  ISession,
+} from "shared/types";
 
 export const compareActivityByName: (
   compareA: IActivity,
@@ -20,6 +25,13 @@ export const compareActivityScheduleByDateAndTime: (
   const compareDateB = toLocalDateTime(compareB.date, compareB.timeOfDay);
 
   return compareAsc(compareDateA, compareDateB);
+};
+
+export const compareCaseReviewsByDate: (
+  compareA: ICaseReview,
+  compareB: ICaseReview,
+) => number = function (compareA, compareB): number {
+  return compareAsc(compareA.date, compareB.date);
 };
 
 export const compareSessionsByDate: (
@@ -50,6 +62,12 @@ export const sortActivitySchedulesByDateAndTime: (
   activitySchedules: IActivitySchedule[],
 ): IActivitySchedule[] {
   return activitySchedules.slice().sort(compareActivityScheduleByDateAndTime);
+};
+
+export const sortCaseReviewsByDate: (
+  caseReviews: ICaseReview[],
+) => ICaseReview[] = function (caseReviews) {
+  return caseReviews.slice().sort(compareCaseReviewsByDate);
 };
 
 export const sortSessionsByDate: (sessions: ISession[]) => ISession[] =

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -10,17 +10,14 @@ import {
 export const compareActivityByName: (
   compareA: IActivity,
   compareB: IActivity,
-) => number = function (compareA: IActivity, compareB: IActivity): number {
+) => number = function (compareA, compareB) {
   return compareStringCaseInsensitive(compareA.name, compareB.name);
 };
 
 export const compareActivityScheduleByDateAndTime: (
   compareA: IActivitySchedule,
   compareB: IActivitySchedule,
-) => number = function (
-  compareA: IActivitySchedule,
-  compareB: IActivitySchedule,
-): number {
+) => number = function (compareA, compareB) {
   const compareDateA = toLocalDateTime(compareA.date, compareA.timeOfDay);
   const compareDateB = toLocalDateTime(compareB.date, compareB.timeOfDay);
 
@@ -37,14 +34,14 @@ export const compareCaseReviewsByDate: (
 export const compareSessionsByDate: (
   compareA: ISession,
   compareB: ISession,
-) => number = function (compareA: ISession, compareB: ISession): number {
+) => number = function (compareA, compareB) {
   return compareAsc(compareA.date, compareB.date);
 };
 
 export const compareStringCaseInsensitive: (
   compareA: string,
   compareB: string,
-) => number = function (compareA: string, compareB: string): number {
+) => number = function (compareA, compareB) {
   const compareInsensitiveA = compareA.toLocaleLowerCase();
   const compareInsensitiveB = compareB.toLocaleLowerCase();
 
@@ -52,15 +49,13 @@ export const compareStringCaseInsensitive: (
 };
 
 export const sortActivitiesByName: (activities: IActivity[]) => IActivity[] =
-  function (activities: IActivity[]): IActivity[] {
+  function (activities) {
     return activities.slice().sort(compareActivityByName);
   };
 
 export const sortActivitySchedulesByDateAndTime: (
   activitySchedules: IActivitySchedule[],
-) => IActivitySchedule[] = function (
-  activitySchedules: IActivitySchedule[],
-): IActivitySchedule[] {
+) => IActivitySchedule[] = function (activitySchedules) {
   return activitySchedules.slice().sort(compareActivityScheduleByDateAndTime);
 };
 
@@ -71,11 +66,11 @@ export const sortCaseReviewsByDate: (
 };
 
 export const sortSessionsByDate: (sessions: ISession[]) => ISession[] =
-  function (sessions: ISession[]): ISession[] {
+  function (sessions) {
     return sessions.slice().sort(compareSessionsByDate);
   };
 
 export const sortStringsCaseInsensitive: (strings: string[]) => string[] =
-  function (strings: string[]): string[] {
+  function (strings) {
     return strings.slice().sort(compareStringCaseInsensitive);
   };


### PR DESCRIPTION
Similar to #479, case reviews have been defaulted sorted by `_id`. This often appears correct, but may not be correct if a case review is edited or otherwise entered in a non-chronological order.

For a pair of case reviews:
![Screenshot 2024-03-17 at 07-49-54 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/9a1dd5f1-9a8d-4a99-a9ce-49e460f594ba)

It was possible for the "Last Case Review" to be incorrect:
![Screenshot 2024-03-17 at 07-50-53 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/1e03bd8d-e9f7-4ed1-bd59-1f377d9797c9)

This update introduces and consistently uses utilities for sorting case reviews by date.