### PR TITLE
Enable Password Reset Using Cognito-Emailed Code

### DIFF
--- a/web_patient/src/components/Chrome/AppHost.tsx
+++ b/web_patient/src/components/Chrome/AppHost.tsx
@@ -162,10 +162,11 @@ export const AppHost: FunctionComponent<IAppHost> = observer((props) => {
                 <a href="tel:2066163032" target="_blank">
                   206-616-3032
                 </a>
-                &nbsp;or&nbsp;
+                &nbsp;or&nbsp; &lt;
                 <a href="mailto:scopestudy@uw.edu" target="_blank">
                   scopestudy@uw.edu
                 </a>
+                &gt;.
               </Typography>
             </FailureContainer>
           )}

--- a/web_patient/src/components/Chrome/AppHost.tsx
+++ b/web_patient/src/components/Chrome/AppHost.tsx
@@ -22,6 +22,7 @@ const LoginContainer = withTheme(
     width: "100%",
     height: "100%",
     display: "flex",
+    alignItems: "flex-start",
     justifyContent: "center",
     overflow: "auto",
     [props.theme.breakpoints.down("md")]: {

--- a/web_patient/src/components/Chrome/AppHost.tsx
+++ b/web_patient/src/components/Chrome/AppHost.tsx
@@ -22,8 +22,8 @@ const LoginContainer = withTheme(
     width: "100%",
     height: "100%",
     display: "flex",
-    alignItems: "center",
     justifyContent: "center",
+    overflow: "auto",
     [props.theme.breakpoints.down("md")]: {
       width: "100%",
       position: "absolute",

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -141,11 +141,7 @@ const LoginForm: FunctionComponent<{
             ),
           }}
         />
-        <Stack
-          direction="row"
-          justifyContent="end"
-          alignItems="center"
-        >
+        <Stack direction="row" justifyContent="end" alignItems="center">
           <Button
             type="button"
             color="primary"
@@ -430,7 +426,7 @@ const PasswordUpdateForm: FunctionComponent<{
         <ul style={{ alignSelf: "flex-start", marginTop: 2 }}>
           {passwordCriteria.map((current, index) => (
             <Fragment key={index}>
-              <li style={{marginLeft: "-15px"}}>
+              <li style={{ marginLeft: "-15px" }}>
                 <Typography
                   variant="subtitle2"
                   component="span"

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -338,7 +338,7 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
 
     return (
       <Container>
-        {authStore.authState == AuthState.NewPasswordRequired ? (
+        {authStore.authState == AuthState.UpdatePasswordInProgress ? (
           <PasswordUpdateForm
             onUpdate={onUpdate}
             error={authStore.authStateDetail}

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -141,6 +141,21 @@ const LoginForm: FunctionComponent<{
             ),
           }}
         />
+        <Stack
+          direction="row"
+          justifyContent="end"
+          alignItems="center"
+        >
+          <Button
+            type="button"
+            color="primary"
+            variant="text"
+            size="small"
+            onClick={onShowResetPassword}
+          >
+            Forgot Password?
+          </Button>
+        </Stack>
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "User does not exist."
@@ -153,18 +168,9 @@ const LoginForm: FunctionComponent<{
         <Stack
           sx={{ paddingTop: 4 }}
           direction="row"
-          spacing={2}
-          justifyContent="space-between"
+          justifyContent="end"
           alignItems="center"
         >
-          <Button
-            type="button"
-            color="primary"
-            variant="text"
-            onClick={onShowResetPassword}
-          >
-            Forgot Password
-          </Button>
           <Button
             type="submit"
             color="primary"
@@ -272,7 +278,7 @@ const PasswordResetForm: FunctionComponent<{
             variant="text"
             onClick={onCancelResetPassword}
           >
-            Cancel Reset
+            Cancel
           </Button>
           <Button
             type="submit"
@@ -281,7 +287,7 @@ const PasswordResetForm: FunctionComponent<{
             onClick={onSubmit}
             disabled={!canSubmit}
           >
-            Send Reset Code
+            Send Code
           </Button>
         </Stack>
       </FormControl>
@@ -424,8 +430,10 @@ const PasswordUpdateForm: FunctionComponent<{
         <ul style={{ alignSelf: "flex-start", marginTop: 2 }}>
           {passwordCriteria.map((current, index) => (
             <Fragment key={index}>
-              <li>
+              <li style={{marginLeft: "-15px"}}>
                 <Typography
+                  variant="subtitle2"
+                  component="span"
                   sx={{
                     color:
                       passwordGotFocus && !!password.trim() && !current.valid
@@ -588,8 +596,7 @@ const PasswordUpdateForm: FunctionComponent<{
             variant="text"
             onClick={onCancelPasswordChange}
           >
-            {isReset && "Cancel Reset"}
-            {isUpdate && "Cancel Sign In"}
+            Cancel
           </Button>
           <Button
             type="submit"
@@ -598,7 +605,8 @@ const PasswordUpdateForm: FunctionComponent<{
             onClick={onSubmit}
             disabled={!canSubmit}
           >
-            Update Password
+            {isReset && "Reset"}
+            {isUpdate && "Update"}
           </Button>
         </Stack>
       </FormControl>

--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -8,6 +8,7 @@ import {
   FormControl,
   FormHelperText,
   InputAdornment,
+  Stack,
   TextField,
   Typography,
 } from "@mui/material";
@@ -31,23 +32,29 @@ const Container = withTheme(
   })),
 );
 
-const ButtonContainer = styled.div({
-  alignSelf: "flex-end",
-  paddingTop: 20,
-});
-
 const LoginForm: FunctionComponent<{
+  account: string;
+  setAccount: (account: string) => void;
+  showPassword: boolean;
+  setShowPassword: (showPassword: boolean) => void;
+  onShowResetPassword: () => void;
   onLogin: (username: string, password: string) => void;
   error?: string;
 }> = (props) => {
-  const { onLogin, error } = props;
-  const [account, setAccount] = useState("");
+  const {
+    account,
+    setAccount,
+    showPassword,
+    setShowPassword,
+    onShowResetPassword,
+    onLogin,
+    error,
+  } = props;
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
 
   const onSubmit = () => {
     // Trim the password in case it has a trailing space
-    onLogin && onLogin(account, password.trim());
+    onLogin(account, password.trim());
   };
 
   const togglePassword = () => {
@@ -67,8 +74,8 @@ const LoginForm: FunctionComponent<{
       <h2>Welcome!</h2>
       <FormControl error={!!error} fullWidth>
         <TextField
-          label="Username"
-          placeholder="Enter username"
+          label="Account"
+          placeholder="Enter account"
           fullWidth
           required
           margin="normal"
@@ -76,7 +83,7 @@ const LoginForm: FunctionComponent<{
           value={account}
           onChange={(e) =>
             setAccount(
-              // Username cannot include whitespace.
+              // Account cannot include whitespace.
               e.target.value.replace(/\s/g, ""),
             )
           }
@@ -135,11 +142,29 @@ const LoginForm: FunctionComponent<{
           }}
         />
         {error && (
-          <FormHelperText id="component-error-text" sx={{ lineHeight: 1 }}>
-            {error}
+          <FormHelperText error={true} sx={{ lineHeight: 1 }}>
+            {error == "User does not exist."
+              ? "Account incorrect."
+              : error == "Incorrect username or password."
+                ? "Password incorrect."
+                : error}
           </FormHelperText>
         )}
-        <ButtonContainer>
+        <Stack
+          sx={{ paddingTop: 4 }}
+          direction="row"
+          spacing={2}
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Button
+            type="button"
+            color="primary"
+            variant="text"
+            onClick={onShowResetPassword}
+          >
+            Forgot Password
+          </Button>
           <Button
             type="submit"
             color="primary"
@@ -147,44 +172,202 @@ const LoginForm: FunctionComponent<{
             onClick={onSubmit}
             disabled={!canLogin}
           >
-            Sign in
+            Sign In
           </Button>
-        </ButtonContainer>
+        </Stack>
+      </FormControl>
+    </Fragment>
+  );
+};
+
+const PasswordResetForm: FunctionComponent<{
+  account: string;
+  setAccount: (account: string) => void;
+  onCancelResetPassword: () => void;
+  onSendResetCode: (username: string) => void;
+  error?: string;
+}> = (props) => {
+  const { account, setAccount, onCancelResetPassword, onSendResetCode, error } =
+    props;
+
+  const onSubmit = () => {
+    onSendResetCode(account);
+  };
+
+  const canSubmit = !!account;
+
+  return (
+    <Fragment>
+      <Avatar
+        alt="Scope logo"
+        src={Logo}
+        sx={{ width: 64, height: 64 }}
+        variant="square"
+      />
+      <h2>Forgot Password?</h2>
+      <Stack
+        direction="column"
+        spacing={2}
+        justifyContent="flex-start"
+        alignItems="flex-start"
+      >
+        <Typography variant="subtitle2">
+          To reset your password, enter your SCOPE account below. We will send a
+          password reset code to the email address associated with that account.
+        </Typography>
+        <Typography variant="subtitle2">
+          If you cannot receive this code, or need other help signing in,
+          contact us at &lt;
+          <a href="mailto:scopestudy@uw.edu" target="_blank">
+            scopestudy@uw.edu
+          </a>
+          &gt;.
+        </Typography>
+      </Stack>
+      <FormControl error={!!error} fullWidth>
+        <TextField
+          label="Account"
+          placeholder="Enter account"
+          fullWidth
+          required
+          margin="normal"
+          variant="standard"
+          value={account}
+          onChange={(e) =>
+            setAccount(
+              // Account cannot include whitespace.
+              e.target.value.replace(/\s/g, ""),
+            )
+          }
+          InputLabelProps={{
+            shrink: true,
+          }}
+          onKeyPress={(e) => {
+            if (e.key === "Enter" && canSubmit) {
+              onSubmit();
+            }
+          }}
+        />
+        {error && (
+          <FormHelperText error={true} sx={{ lineHeight: 1 }}>
+            {error == "Username/client id combination not found."
+              ? "Account incorrect."
+              : error == "Attempt limit exceeded, please try after some time."
+                ? "Reset attempt limit exceeded. Try again later."
+                : error == "User password cannot be reset in the current state."
+                  ? "Reset code not available. Contact study team."
+                  : error}
+          </FormHelperText>
+        )}
+        <Stack
+          sx={{ paddingTop: 4 }}
+          direction="row"
+          spacing={2}
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Button
+            type="button"
+            color="primary"
+            variant="text"
+            onClick={onCancelResetPassword}
+          >
+            Cancel Reset
+          </Button>
+          <Button
+            type="submit"
+            color="primary"
+            variant="contained"
+            onClick={onSubmit}
+            disabled={!canSubmit}
+          >
+            Send Reset Code
+          </Button>
+        </Stack>
       </FormControl>
     </Fragment>
   );
 };
 
 const PasswordUpdateForm: FunctionComponent<{
-  onUpdate: (password: string) => void;
+  showPassword: boolean;
+  setShowPassword: (showPassword: boolean) => void;
+  onCancelPasswordChange: () => void;
+  onReset?: (resetCode: string, password: string) => void;
+  onUpdate?: (password: string) => void;
   error?: string;
 }> = (props) => {
-  const { onUpdate, error } = props;
+  const {
+    showPassword,
+    setShowPassword,
+    onCancelPasswordChange,
+    onReset,
+    onUpdate,
+    error,
+  } = props;
+  const [resetCode, setResetCode] = useState("");
   const [password, setPassword] = useState("");
   const [passwordRepeat, setPasswordRepeat] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
+  const [resetCodeHasFocus, setResetCodeHasFocus] = useState(false);
+  const [resetCodeGotFocus, setResetCodeGotFocus] = useState(false);
+  const [passwordGotFocus, setPasswordGotFocus] = useState(false);
+  const [confirmPasswordGotFocus, setConfirmPasswordGotFocus] = useState(false);
+
+  const isReset = !!onReset;
+  const isUpdate = !!onUpdate;
+
+  const passwordCriteria: { description: string; valid: boolean }[] = [
+    {
+      // Allowable length
+      description: "At least 8 characters.",
+      valid: password.length >= 8 && password.length <= 128,
+    },
+    {
+      // Require uppercase
+      description: "Must contain an uppercase letter.",
+      valid: !!password.match(/(?=.*[A-Z])/),
+    },
+    {
+      // Require lowercase
+      description: "Must contain a lowercase letter.",
+      valid: !!password.match(/(?=.*[a-z])/),
+    },
+    {
+      // Require digit
+      description: "Must contain a digit.",
+      valid: !!password.match(/(?=.*[0-9])/),
+    },
+    {
+      // Require symbol
+      // Defined by Cognito as ^ $ * . [ ] { } ( ) ? " ! @ # % & / \ , > < ' : ; | _ ~ ` = + -
+      // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html
+      description: "Must contain a symbol character.",
+      valid: !!password.match(
+        /(?=.*[\^$*.\[\]{}\(\)?“!@#%&/\\,><\’:;|_~`=+\-])/,
+      ),
+    },
+    {
+      // No space (e.g., no interior space)
+      // Cognito will allow an interior space, but we will not
+      description: "Must not include a space.",
+      valid: !!password.match(/^\S*$/),
+    },
+  ];
 
   const validPassword =
     // Password exists
     !!password &&
-    // Allowable length
-    password.length >= 8 &&
-    password.length <= 128 &&
-    // No space (e.g., no interior space)
-    // Cognito will allow an interior space, but we will not
-    !!password.match(/^\S+$/) &&
-    // Require uppercase
-    !!password.match(/(?=.*[A-Z])/) &&
-    // Require lowercase
-    !!password.match(/(?=.*[a-z])/) &&
-    // Require digit
-    !!password.match(/(?=.*[0-9])/) &&
-    // Require symbol
-    // Defined by Cognito as ^ $ * . [ ] { } ( ) ? " ! @ # % & / \ , > < ' : ; | _ ~ ` = + -
-    // https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html
-    !!password.match(/(?=.*[\^$*.\[\]{}\(\)?“!@#%&/\\,><\’:;|_~`=+\-])/);
+    // Meets all criteria
+    passwordCriteria.reduce((combinedValid, current) => {
+      return combinedValid && current.valid;
+    }, true);
 
   const canSubmit: boolean =
+    // Update does not require a code
+    (isUpdate ||
+      // Reset requires a code
+      (isReset && !!resetCode)) &&
+    // Password must be valid
     validPassword &&
     // Passwords must match
     // Trim any trailing space before comparing
@@ -192,7 +375,11 @@ const PasswordUpdateForm: FunctionComponent<{
     password.trim() === passwordRepeat.trim();
 
   const onSubmit = () => {
-    canSubmit && !!onUpdate && onUpdate(password.trim());
+    if (isUpdate) {
+      canSubmit && !!onUpdate && onUpdate(password.trim());
+    } else if (isReset) {
+      canSubmit && !!onReset && onReset(resetCode.trim(), password.trim());
+    }
   };
 
   const togglePassword = () => {
@@ -202,37 +389,88 @@ const PasswordUpdateForm: FunctionComponent<{
   return (
     <Fragment>
       <Avatar alt="Scope logo" src={Logo} />
-      <h2>Update password</h2>
-      <Typography variant="subtitle2">
-        Please generate a password that meets the following criteria:
-      </Typography>
-      <ul style={{ alignSelf: "flex-start" }}>
-        <li>
-          <Typography variant="caption">At least 8 characters</Typography>
-        </li>
-        <li>
-          <Typography variant="caption">
-            Must contain uppercase letters
+      {isReset && <h2>Reset Password</h2>}
+      {isUpdate && <h2>Update Password</h2>}
+      <Stack
+        direction="column"
+        spacing={2}
+        justifyContent="flex-start"
+        alignItems="flex-start"
+      >
+        {isReset && (
+          <React.Fragment>
+            <Typography variant="subtitle2">
+              We have sent a password reset code to the email address associated
+              with your SCOPE account. The reset code will expire after 1 hour.
+            </Typography>
+            <Typography variant="subtitle2">
+              If you cannot receive this code, or need other help signing in,
+              contact us at &lt;
+              <a href="mailto:scopestudy@uw.edu" target="_blank">
+                scopestudy@uw.edu
+              </a>
+              &gt;.
+            </Typography>
+          </React.Fragment>
+        )}
+        {isUpdate && (
+          <Typography variant="subtitle2">
+            Sign in requires updating your SCOPE password.
           </Typography>
-        </li>
-        <li>
-          <Typography variant="caption">
-            Must contain lowercase letters
-          </Typography>
-        </li>
-        <li>
-          <Typography variant="caption">Must contain digits</Typography>
-        </li>
-        <li>
-          <Typography variant="caption">
-            Must contain symbol characters
-          </Typography>
-        </li>
-        <li>
-          <Typography variant="caption">Must not include spaces</Typography>
-        </li>
-      </ul>
+        )}
+        <Typography variant="subtitle2">
+          Create a password that meets the following criteria:
+        </Typography>
+        <ul style={{ alignSelf: "flex-start", marginTop: 2 }}>
+          {passwordCriteria.map((current, index) => (
+            <Fragment key={index}>
+              <li>
+                <Typography
+                  sx={{
+                    color:
+                      passwordGotFocus && !!password.trim() && !current.valid
+                        ? "error.main"
+                        : undefined,
+                    marginBottom: 1,
+                  }}
+                >
+                  {current.description}
+                </Typography>
+              </li>
+            </Fragment>
+          ))}
+        </ul>
+      </Stack>
       <FormControl error={!!error} fullWidth>
+        {isReset && (
+          <TextField
+            label="Reset Code"
+            placeholder="Enter reset code"
+            type="text"
+            fullWidth
+            required
+            variant="standard"
+            margin="normal"
+            value={resetCode}
+            onFocus={() => {
+              setResetCodeHasFocus(true);
+              setResetCodeGotFocus(true);
+            }}
+            onBlur={() => {
+              setResetCodeHasFocus(false);
+            }}
+            onChange={(e) =>
+              setResetCode(
+                // Not allowing spaces
+                e.target.value.trim(),
+              )
+            }
+            InputLabelProps={{
+              shrink: true,
+            }}
+            error={!resetCodeHasFocus && resetCodeGotFocus && !resetCode.trim()}
+          />
+        )}
         <TextField
           label="Password"
           placeholder="Enter password"
@@ -242,6 +480,9 @@ const PasswordUpdateForm: FunctionComponent<{
           variant="standard"
           margin="normal"
           value={password}
+          onFocus={() => {
+            setPasswordGotFocus(true);
+          }}
           onChange={(e) =>
             setPassword(
               // Cognito allows passwords to include an interior space,
@@ -272,17 +513,20 @@ const PasswordUpdateForm: FunctionComponent<{
               </InputAdornment>
             ),
           }}
-          error={!validPassword}
+          error={passwordGotFocus && !!password.trim() && !validPassword}
         />
         <TextField
           label="Confirm Password"
           placeholder="Confirm password"
-          type="password"
+          type={showPassword ? "text" : "password"}
           fullWidth
           required
           variant="standard"
           margin="normal"
           value={passwordRepeat}
+          onFocus={() => {
+            setConfirmPasswordGotFocus(true);
+          }}
           onChange={(e) =>
             setPasswordRepeat(
               // Cognito allows passwords to include an interior space,
@@ -301,14 +545,52 @@ const PasswordUpdateForm: FunctionComponent<{
               onSubmit();
             }
           }}
-          error={!canSubmit}
+          error={
+            confirmPasswordGotFocus &&
+            !!passwordRepeat.trim() &&
+            (!validPassword || password.trim() != passwordRepeat.trim())
+          }
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                {showPassword ? (
+                  <VisibilityIcon
+                    sx={{ cursor: "pointer" }}
+                    onClick={togglePassword}
+                  />
+                ) : (
+                  <VisibilityOffIcon
+                    sx={{ cursor: "pointer" }}
+                    onClick={togglePassword}
+                  />
+                )}
+              </InputAdornment>
+            ),
+          }}
         />
         {error && (
-          <FormHelperText id="component-error-text" sx={{ lineHeight: 1 }}>
-            {error}
+          <FormHelperText error={true} sx={{ lineHeight: 1 }}>
+            {error == "Invalid verification code provided, please try again."
+              ? "Password reset code incorrect."
+              : error}
           </FormHelperText>
         )}
-        <ButtonContainer>
+        <Stack
+          sx={{ paddingTop: 4 }}
+          direction="row"
+          spacing={2}
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Button
+            type="button"
+            color="primary"
+            variant="text"
+            onClick={onCancelPasswordChange}
+          >
+            {isReset && "Cancel Reset"}
+            {isUpdate && "Cancel Sign In"}
+          </Button>
           <Button
             type="submit"
             color="primary"
@@ -316,9 +598,9 @@ const PasswordUpdateForm: FunctionComponent<{
             onClick={onSubmit}
             disabled={!canSubmit}
           >
-            Update password
+            Update Password
           </Button>
-        </ButtonContainer>
+        </Stack>
       </FormControl>
     </Fragment>
   );
@@ -328,6 +610,9 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
   (props) => {
     const { authStore } = props;
 
+    const [account, setAccount] = useState("");
+    const [showPassword, setShowPassword] = useState(false);
+
     const onLogin = (username: string, password: string) => {
       authStore.login(username, password);
     };
@@ -336,15 +621,61 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
       authStore.updateTempPassword(password);
     };
 
+    const onSendResetCode = (username: string) => {
+      authStore.sendResetPasswordCode(username);
+    };
+
+    const onReset = (code: string, password: string) => {
+      authStore.resetPassword(code, password);
+    };
+
     return (
       <Container>
-        {authStore.authState == AuthState.UpdatePasswordInProgress ? (
+        {authStore.authState == AuthState.UpdatePasswordInProgress ||
+        authStore.authState == AuthState.ResetPasswordInProgress ? (
           <PasswordUpdateForm
-            onUpdate={onUpdate}
+            showPassword={showPassword}
+            setShowPassword={setShowPassword}
+            onCancelPasswordChange={() => {
+              authStore.authState = AuthState.Initialized;
+              authStore.clearDetail();
+            }}
+            onReset={
+              authStore.authState == AuthState.ResetPasswordInProgress
+                ? onReset
+                : undefined
+            }
+            onUpdate={
+              authStore.authState == AuthState.UpdatePasswordInProgress
+                ? onUpdate
+                : undefined
+            }
+            error={authStore.authStateDetail}
+          />
+        ) : authStore.authState == AuthState.ResetPasswordPrompt ? (
+          <PasswordResetForm
+            account={account}
+            setAccount={setAccount}
+            onCancelResetPassword={() => {
+              authStore.authState = AuthState.Initialized;
+              authStore.clearDetail();
+            }}
+            onSendResetCode={onSendResetCode}
             error={authStore.authStateDetail}
           />
         ) : (
-          <LoginForm onLogin={onLogin} error={authStore.authStateDetail} />
+          <LoginForm
+            account={account}
+            setAccount={setAccount}
+            showPassword={showPassword}
+            setShowPassword={setShowPassword}
+            onShowResetPassword={() => {
+              authStore.authState = AuthState.ResetPasswordPrompt;
+              authStore.clearDetail();
+            }}
+            onLogin={onLogin}
+            error={authStore.authStateDetail}
+          />
         )}
       </Container>
     );

--- a/web_patient/src/services/strings.ts
+++ b/web_patient/src/services/strings.ts
@@ -309,8 +309,8 @@ const _strings = {
   Resources_about_us_subtitle: "Learn about the study",
   Resources_crisis_resources_title: "Crisis Help",
   Resources_crisis_resources_subtitle: "Crisis resources and hotlines",
-  Resources_logout_title: "Log out",
-  Resources_logout_subtitle: "Log out of the app",
+  Resources_logout_title: "Sign Out",
+  Resources_logout_subtitle: "Sign out of the app",
 
   Safetyplan_title: "Safety Plan",
   Safetyplan_reasons_for_living_title: "Reasons for living",

--- a/web_registry/src/components/chrome/AppHost.tsx
+++ b/web_registry/src/components/chrome/AppHost.tsx
@@ -44,6 +44,7 @@ const LoginContainer = withTheme(
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
+    overflow: "auto",
     [props.theme.breakpoints.down("md")]: {
       width: "100%",
       position: "absolute",

--- a/web_registry/src/components/chrome/AppHost.tsx
+++ b/web_registry/src/components/chrome/AppHost.tsx
@@ -169,7 +169,12 @@ export const AppHost: FunctionComponent<IAppHost> = observer((props) => {
           </ImageContainer>
           <LoginContainer>
             {!!state.store ? (
-              <Login authStore={state.store.authStore} />
+              // When already authenticated,
+              // do not render the Login component.
+              // This also ensures all Login state is cleared.
+              !state.store.authStore.isAuthenticated && (
+                <Login authStore={state.store.authStore} />
+              )
             ) : !state.failed ? (
               <ProgressContainer>
                 <CircularProgress />

--- a/web_registry/src/components/chrome/HeaderContent.tsx
+++ b/web_registry/src/components/chrome/HeaderContent.tsx
@@ -73,7 +73,7 @@ export const HeaderContent: FunctionComponent = observer(() => {
           open={Boolean(state.anchorEl)}
           onClose={() => handleClose()}
         >
-          <MenuItem onClick={(_) => handleLogout()}>Log out</MenuItem>
+          <MenuItem onClick={(_) => handleLogout()}>Sign Out</MenuItem>
         </Menu>
         <Button color="inherit" onClick={(e) => handleClickName(e)}>
           {rootStore.authStore.currentUserIdentity?.name}

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -76,7 +76,7 @@ const LoginForm: FunctionComponent<{
           value={account}
           onChange={(e) =>
             setAccount(
-              // Username cannot include whitespace.
+              // Account cannot include whitespace.
               e.target.value.replace(/\s/g, ""),
             )
           }

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -141,11 +141,7 @@ const LoginForm: FunctionComponent<{
             ),
           }}
         />
-        <Stack
-          direction="row"
-          justifyContent="end"
-          alignItems="center"
-        >
+        <Stack direction="row" justifyContent="end" alignItems="center">
           <Button
             type="button"
             color="primary"
@@ -430,7 +426,7 @@ const PasswordUpdateForm: FunctionComponent<{
         <ul style={{ alignSelf: "flex-start", marginTop: 2 }}>
           {passwordCriteria.map((current, index) => (
             <Fragment key={index}>
-              <li style={{marginLeft: "-15px"}}>
+              <li style={{ marginLeft: "-15px" }}>
                 <Typography
                   variant="subtitle2"
                   component="span"

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -132,7 +132,7 @@ const LoginForm: FunctionComponent<{
           }}
         />
         {error && (
-          <FormHelperText id="component-error-text" sx={{ lineHeight: 1 }}>
+          <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "User does not exist."
               ? "Account not found."
               : error == "Incorrect username or password."
@@ -200,9 +200,8 @@ const PasswordResetForm: FunctionComponent<{
         alignItems="flex-start"
       >
         <Typography variant="subtitle2">
-          To reset your password, enter your SCOPE account below. We will
-          send a password reset code to the email address associated with that
-          account.
+          To reset your password, enter your SCOPE account below. We will send a
+          password reset code to the email address associated with that account.
         </Typography>
         <Typography variant="subtitle2">
           If you cannot receive this code, or need other help signing in,
@@ -238,11 +237,7 @@ const PasswordResetForm: FunctionComponent<{
           }}
         />
         {error && (
-          <FormHelperText
-            error={true}
-            // id="component-error-text"
-            sx={{ lineHeight: 1 }}
-          >
+          <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "Username/client id combination not found."
               ? "Account not found."
               : error == "Attempt limit exceeded, please try after some time."
@@ -374,7 +369,8 @@ const PasswordUpdateForm: FunctionComponent<{
   return (
     <Fragment>
       <Avatar alt="Scope logo" src={Logo} />
-      <h2>Update Password</h2>
+      {isReset && <h2>Reset Password</h2>}
+      {isUpdate && <h2>Update Password</h2>}
       <Stack
         direction="column"
         spacing={2}
@@ -543,12 +539,10 @@ const PasswordUpdateForm: FunctionComponent<{
           }}
         />
         {error && (
-          <FormHelperText
-            // id="component-error-text"
-            error={true}
-            sx={{ lineHeight: 1 }}
-          >
-            {error}
+          <FormHelperText error={true} sx={{ lineHeight: 1 }}>
+            {error == "Invalid verification code provided, please try again."
+              ? "Invalid password reset code."
+              : error}
           </FormHelperText>
         )}
         <Stack

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -33,14 +33,24 @@ const Container = withTheme(
 );
 
 const LoginForm: FunctionComponent<{
+  account: string;
+  setAccount: (account: string) => void;
+  showPassword: boolean;
+  setShowPassword: (showPassword: boolean) => void;
   onShowResetPassword: () => void;
   onLogin: (username: string, password: string) => void;
   error?: string;
 }> = (props) => {
-  const { onShowResetPassword, onLogin, error } = props;
-  const [account, setAccount] = useState("");
+  const {
+    account,
+    setAccount,
+    showPassword,
+    setShowPassword,
+    onShowResetPassword,
+    onLogin,
+    error,
+  } = props;
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
 
   const onSubmit = () => {
     // Trim the password in case it has a trailing space
@@ -171,12 +181,14 @@ const LoginForm: FunctionComponent<{
 };
 
 const PasswordResetForm: FunctionComponent<{
+  account: string;
+  setAccount: (account: string) => void;
   onCancelResetPassword: () => void;
   onSendResetCode: (username: string) => void;
   error?: string;
 }> = (props) => {
-  const { onCancelResetPassword, onSendResetCode, error } = props;
-  const [account, setAccount] = useState("");
+  const { account, setAccount, onCancelResetPassword, onSendResetCode, error } =
+    props;
 
   const onSubmit = () => {
     onSendResetCode(account);
@@ -278,16 +290,24 @@ const PasswordResetForm: FunctionComponent<{
 };
 
 const PasswordUpdateForm: FunctionComponent<{
+  showPassword: boolean;
+  setShowPassword: (showPassword: boolean) => void;
   onCancelPasswordChange: () => void;
   onReset?: (resetCode: string, password: string) => void;
   onUpdate?: (password: string) => void;
   error?: string;
 }> = (props) => {
-  const { onCancelPasswordChange, onReset, onUpdate, error } = props;
+  const {
+    showPassword,
+    setShowPassword,
+    onCancelPasswordChange,
+    onReset,
+    onUpdate,
+    error,
+  } = props;
   const [resetCode, setResetCode] = useState("");
   const [password, setPassword] = useState("");
   const [passwordRepeat, setPasswordRepeat] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [resetCodeHasFocus, setResetCodeHasFocus] = useState(false);
   const [resetCodeGotFocus, setResetCodeGotFocus] = useState(false);
   const [passwordGotFocus, setPasswordGotFocus] = useState(false);
@@ -580,6 +600,9 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
   (props) => {
     const { authStore } = props;
 
+    const [account, setAccount] = useState("");
+    const [showPassword, setShowPassword] = useState(false);
+
     const onLogin = (username: string, password: string) => {
       authStore.login(username, password);
     };
@@ -601,6 +624,8 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
         {authStore.authState == AuthState.UpdatePasswordInProgress ||
         authStore.authState == AuthState.ResetPasswordInProgress ? (
           <PasswordUpdateForm
+            showPassword={showPassword}
+            setShowPassword={setShowPassword}
             onCancelPasswordChange={() => {
               authStore.authState = AuthState.Initialized;
             }}
@@ -618,6 +643,8 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
           />
         ) : authStore.authState == AuthState.ResetPasswordPrompt ? (
           <PasswordResetForm
+            account={account}
+            setAccount={setAccount}
             onCancelResetPassword={() => {
               authStore.authState = AuthState.Initialized;
               authStore.clearDetail();
@@ -627,6 +654,10 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
           />
         ) : (
           <LoginForm
+            account={account}
+            setAccount={setAccount}
+            showPassword={showPassword}
+            setShowPassword={setShowPassword}
             onShowResetPassword={() => {
               authStore.authState = AuthState.ResetPasswordPrompt;
               authStore.clearDetail();

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -277,7 +277,7 @@ const PasswordUpdateForm: FunctionComponent<{
         <TextField
           label="Confirm Password"
           placeholder="Confirm password"
-          type="password"
+          type={showPassword ? "text" : "password"}
           fullWidth
           required
           variant="standard"
@@ -302,6 +302,23 @@ const PasswordUpdateForm: FunctionComponent<{
             }
           }}
           error={!canSubmit}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                {showPassword ? (
+                  <VisibilityIcon
+                    sx={{ cursor: "pointer" }}
+                    onClick={togglePassword}
+                  />
+                ) : (
+                  <VisibilityOffIcon
+                    sx={{ cursor: "pointer" }}
+                    onClick={togglePassword}
+                  />
+                )}
+              </InputAdornment>
+            ),
+          }}
         />
         {error && (
           <FormHelperText id="component-error-text" sx={{ lineHeight: 1 }}>

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -141,6 +141,21 @@ const LoginForm: FunctionComponent<{
             ),
           }}
         />
+        <Stack
+          direction="row"
+          justifyContent="end"
+          alignItems="center"
+        >
+          <Button
+            type="button"
+            color="primary"
+            variant="text"
+            size="small"
+            onClick={onShowResetPassword}
+          >
+            Forgot Password?
+          </Button>
+        </Stack>
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "User does not exist."
@@ -153,18 +168,9 @@ const LoginForm: FunctionComponent<{
         <Stack
           sx={{ paddingTop: 4 }}
           direction="row"
-          spacing={2}
-          justifyContent="space-between"
+          justifyContent="end"
           alignItems="center"
         >
-          <Button
-            type="button"
-            color="primary"
-            variant="text"
-            onClick={onShowResetPassword}
-          >
-            Forgot Password
-          </Button>
           <Button
             type="submit"
             color="primary"
@@ -272,7 +278,7 @@ const PasswordResetForm: FunctionComponent<{
             variant="text"
             onClick={onCancelResetPassword}
           >
-            Cancel Reset
+            Cancel
           </Button>
           <Button
             type="submit"
@@ -281,7 +287,7 @@ const PasswordResetForm: FunctionComponent<{
             onClick={onSubmit}
             disabled={!canSubmit}
           >
-            Send Reset Code
+            Send Code
           </Button>
         </Stack>
       </FormControl>
@@ -424,8 +430,10 @@ const PasswordUpdateForm: FunctionComponent<{
         <ul style={{ alignSelf: "flex-start", marginTop: 2 }}>
           {passwordCriteria.map((current, index) => (
             <Fragment key={index}>
-              <li>
+              <li style={{marginLeft: "-15px"}}>
                 <Typography
+                  variant="subtitle2"
+                  component="span"
                   sx={{
                     color:
                       passwordGotFocus && !!password.trim() && !current.valid
@@ -588,8 +596,7 @@ const PasswordUpdateForm: FunctionComponent<{
             variant="text"
             onClick={onCancelPasswordChange}
           >
-            {isReset && "Cancel Reset"}
-            {isUpdate && "Cancel Sign In"}
+            Cancel
           </Button>
           <Button
             type="submit"
@@ -598,7 +605,8 @@ const PasswordUpdateForm: FunctionComponent<{
             onClick={onSubmit}
             disabled={!canSubmit}
           >
-            Update Password
+            {isReset && "Reset"}
+            {isUpdate && "Update"}
           </Button>
         </Stack>
       </FormControl>

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -144,7 +144,7 @@ const LoginForm: FunctionComponent<{
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "User does not exist."
-              ? "Account not found."
+              ? "Account incorrect."
               : error == "Incorrect username or password."
                 ? "Password incorrect."
                 : error}
@@ -251,7 +251,7 @@ const PasswordResetForm: FunctionComponent<{
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "Username/client id combination not found."
-              ? "Account not found."
+              ? "Account incorrect."
               : error == "Attempt limit exceeded, please try after some time."
                 ? "Reset attempt limit exceeded. Try again later."
                 : error == "User password cannot be reset in the current state."
@@ -571,7 +571,7 @@ const PasswordUpdateForm: FunctionComponent<{
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "Invalid verification code provided, please try again."
-              ? "Invalid password reset code."
+              ? "Password reset code incorrect."
               : error}
           </FormHelperText>
         )}
@@ -638,6 +638,7 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
             setShowPassword={setShowPassword}
             onCancelPasswordChange={() => {
               authStore.authState = AuthState.Initialized;
+              authStore.clearDetail();
             }}
             onReset={
               authStore.authState == AuthState.ResetPasswordInProgress

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -580,8 +580,6 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
   (props) => {
     const { authStore } = props;
 
-    const [showResetPassword, setShowResetPassword] = useState(false);
-
     const onLogin = (username: string, password: string) => {
       authStore.login(username, password);
     };
@@ -600,12 +598,11 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
 
     return (
       <Container>
-        {authStore.authState == AuthState.NewPasswordRequired ||
+        {authStore.authState == AuthState.UpdatePasswordInProgress ||
         authStore.authState == AuthState.ResetPasswordInProgress ? (
           <PasswordUpdateForm
             onCancelPasswordChange={() => {
               authStore.authState = AuthState.Initialized;
-              setShowResetPassword(false);
             }}
             onReset={
               authStore.authState == AuthState.ResetPasswordInProgress
@@ -613,17 +610,17 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
                 : undefined
             }
             onUpdate={
-              authStore.authState == AuthState.NewPasswordRequired
+              authStore.authState == AuthState.UpdatePasswordInProgress
                 ? onUpdate
                 : undefined
             }
             error={authStore.authStateDetail}
           />
-        ) : showResetPassword ? (
+        ) : authStore.authState == AuthState.ResetPasswordPrompt ? (
           <PasswordResetForm
             onCancelResetPassword={() => {
+              authStore.authState = AuthState.Initialized;
               authStore.clearDetail();
-              setShowResetPassword(false);
             }}
             onSendResetCode={onSendResetCode}
             error={authStore.authStateDetail}
@@ -631,8 +628,8 @@ export const Login: FunctionComponent<{ authStore: IAuthStore }> = observer(
         ) : (
           <LoginForm
             onShowResetPassword={() => {
+              authStore.authState = AuthState.ResetPasswordPrompt;
               authStore.clearDetail();
-              setShowResetPassword(true);
             }}
             onLogin={onLogin}
             error={authStore.authStateDetail}

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -217,7 +217,7 @@ const PasswordResetForm: FunctionComponent<{
         </Typography>
         <Typography variant="subtitle2">
           If you cannot receive this code, or need other help signing in,
-          contact us at &nbsp;&lt;
+          contact us at &lt;
           <a href="mailto:scopestudy@uw.edu" target="_blank">
             scopestudy@uw.edu
           </a>
@@ -398,10 +398,20 @@ const PasswordUpdateForm: FunctionComponent<{
         alignItems="flex-start"
       >
         {isReset && (
-          <Typography variant="subtitle2">
-            We have sent a password reset code to the email address associated
-            with your SCOPE account. The reset code will expire after 1 hour.
-          </Typography>
+          <React.Fragment>
+            <Typography variant="subtitle2">
+              We have sent a password reset code to the email address associated
+              with your SCOPE account. The reset code will expire after 1 hour.
+            </Typography>
+            <Typography variant="subtitle2">
+              If you cannot receive this code, or need other help signing in,
+              contact us at &lt;
+              <a href="mailto:scopestudy@uw.edu" target="_blank">
+                scopestudy@uw.edu
+              </a>
+              &gt;.
+            </Typography>
+          </React.Fragment>
         )}
         {isUpdate && (
           <Typography variant="subtitle2">

--- a/web_shared/authStoreBase.ts
+++ b/web_shared/authStoreBase.ts
@@ -21,8 +21,10 @@ import { IAppAuthConfig, IIdentity } from "shared/types";
 
 export enum AuthState {
   Initialized,
-  NewPasswordRequired,
+  UpdatePasswordInProgress,
+  ResetPasswordPrompt,
   ResetPasswordInProgress,
+  ResetPasswordComplete,
   Authenticated,
   AuthenticationFailed,
 }
@@ -196,7 +198,7 @@ export class AuthStoreBase<T extends IIdentity> implements IAuthStoreBase<T> {
           logger.event("newPasswordRequired", data);
           runInAction(() => {
             this.authUser = authUser;
-            this.authState = AuthState.NewPasswordRequired;
+            this.authState = AuthState.UpdatePasswordInProgress;
           });
           reject("newPasswordRequired");
         }),
@@ -262,7 +264,7 @@ export class AuthStoreBase<T extends IIdentity> implements IAuthStoreBase<T> {
               this.authState =
                 err.code == "NotAuthorizedException"
                   ? AuthState.AuthenticationFailed
-                  : AuthState.NewPasswordRequired;
+                  : AuthState.UpdatePasswordInProgress;
             });
             reject(err);
           }),
@@ -338,8 +340,8 @@ export class AuthStoreBase<T extends IIdentity> implements IAuthStoreBase<T> {
             });
 
             this.authStateDetail =
-              "Password reset successful. Please log in again using the new password.";
-            this.authState = AuthState.Initialized;
+              "Password reset successful. Sign in using the new password.";
+            this.authState = AuthState.ResetPasswordComplete;
             resolve(undefined);
           }),
           onFailure: action((err: any) => {

--- a/web_shared/authStoreBase.ts
+++ b/web_shared/authStoreBase.ts
@@ -312,8 +312,6 @@ export class AuthStoreBase<T extends IIdentity> implements IAuthStoreBase<T> {
             logger.error(err);
             runInAction(() => {
               this.authStateDetail = err.message;
-
-              this.authState = AuthState.AuthenticationFailed;
             });
             reject(err);
           }),

--- a/web_shared/authStoreBase.ts
+++ b/web_shared/authStoreBase.ts
@@ -417,8 +417,8 @@ export class AuthStoreBase<T extends IIdentity> implements IAuthStoreBase<T> {
           runInAction(() => {
             this.authState = AuthState.AuthenticationFailed;
             this.authStateDetail = unauthorized
-              ? "Sorry, you are not authorized to access this service"
-              : "Sorry, there was an issue accessing the service";
+              ? "Sorry, you are not authorized to access this service."
+              : "Sorry, there was an issue accessing the service.";
           });
         }
       });

--- a/web_shared/authStoreBase.ts
+++ b/web_shared/authStoreBase.ts
@@ -25,8 +25,8 @@ export enum AuthState {
   ResetPasswordPrompt,
   ResetPasswordInProgress,
   ResetPasswordComplete,
-  Authenticated,
   AuthenticationFailed,
+  Authenticated,
 }
 
 export interface IAuthStoreBase<T extends IIdentity> {

--- a/web_shared/authStoreBase.ts
+++ b/web_shared/authStoreBase.ts
@@ -340,7 +340,7 @@ export class AuthStoreBase<T extends IIdentity> implements IAuthStoreBase<T> {
             });
 
             this.authStateDetail =
-              "Password reset successful. Sign in using the new password.";
+              "Reset successful. Sign in using the new password.";
             this.authState = AuthState.ResetPasswordComplete;
             resolve(undefined);
           }),


### PR DESCRIPTION
Implement password resets via emailed code, together with server updates in:

https://github.com/uwscope/scope-aws-infrastructure/pull/30

Adds a "Forgot Password?" prompt at login, which toggle a reset request form:

| | Registry | App |
| - | - | - |
| Login | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/6ac98910-3b72-4cca-bb2f-ae49d83f6f40"/> | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/ed2aac6c-926d-48b6-ac4b-c5c4bb6ccb7d" /> <tr></tr> |
| Reset Request | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/58e7c893-db98-4172-8b80-6449c689d7fb"/> | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/d0c5b014-d938-4ac1-bafe-aedd63f05f15" /> <tr></tr> |

Request generates an email:

<img width=500 src="https://github.com/uwscope/scope-web/assets/2163573/4fbe30ba-a09e-47bd-af38-62871ed683cf" />

This code and a new password are entered:

| | Registry | App |
| - | - | - |
| Reset Password | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/2e83b174-a889-454c-8eda-68e861b59f40"/> | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/cd4fad6a-7270-4c4e-b1a3-4bbd301c5c3d" /> <tr></tr> |

Confirmation is provided, and several account / password error conditions are handled (shown only with registry, the app provides identical error messages):

| | Registry |
| - | - |
| Confirmation of Reset | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/3db1602a-479e-4bd8-85d0-ce9f063ec7d9"/> <tr></tr> |
| Sign In Account Incorrect | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/143d5844-b93b-4777-99a3-b211c1dcd11a"/> <tr></tr> |
| Sign In Password Incorrect | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/d55c40d2-5398-455d-93a9-857e1bb62930"/> <tr></tr> |
| Reset Account Incorrect | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/0538fe99-eefd-4297-baad-e7d06c1b1525"/> <tr></tr> |
| Reset Code Incorrect | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/aab2cc2e-d229-4efa-916d-423f73b0bb44"/> <tr></tr> |

Cognito rate limits reset requests:

| | Registry |
| - | - |
| Rate Limit | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/f1a9cad8-1cdc-4932-9322-c175a180ddab"/> <tr></tr> |

Cognito does not allow a reset request if a person currently has a temporary password (i.e., reset by us):

| | Registry |
| - | - |
| Temporary Password | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/b340fd95-3d84-4386-8b5d-8811f8517cf5"/> <tr></tr> |

Includes more precise password validation feedback during update / reset:

| | Registry | App |
| - | - | - |
| Update Password Validation | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/99d7042e-16f0-4357-8c30-851ae29faa18"/> | <img width=250 src="https://github.com/uwscope/scope-web/assets/2163573/34adf4fa-10ce-4ee1-af84-dca809b86ed6" /> <tr></tr> |
