### PR TITLE
Improved Error Message for Password Attempt Limit

### DIFF
--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -158,7 +158,9 @@ const LoginForm: FunctionComponent<{
               ? "Account incorrect."
               : error == "Incorrect username or password."
                 ? "Password incorrect."
-                : error}
+                : error == "Password attempts exceeded"
+                  ? "Password attempt limit exceeded. Try again later."
+                  : error}
           </FormHelperText>
         )}
         <Stack

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -158,7 +158,9 @@ const LoginForm: FunctionComponent<{
               ? "Account incorrect."
               : error == "Incorrect username or password."
                 ? "Password incorrect."
-                : error}
+                : error == "Password attempts exceeded"
+                  ? "Password attempt limit exceeded. Try again later."
+                  : error}
           </FormHelperText>
         )}
         <Stack


### PR DESCRIPTION
Improved error message for password attempt limit.

This condition was not explicitly handled.

![Screenshot 2024-04-15 at 18-10-21 SCOPE Registry](https://github.com/uwscope/scope-web/assets/2163573/dadf8bab-3db2-46ee-82e6-403f7d0c4499)
