### PR TITLE
Patient Store Support to Sort Assessment Logs by Date and Time

### DIFF
--- a/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
+++ b/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
@@ -307,9 +307,7 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
 
     const onRowClick = action((param: GridRowParams) => {
       const id = param.row["id"] as string;
-      const data = assessmentLogsSortedByDate.find(
-        (a) => a.assessmentLogId == id,
-      );
+      const data = currentPatient.getAssessmentLogById(id);
       if (!!data) {
         logState.openEdit = true;
         logState.log = { ...data };

--- a/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
+++ b/web_registry/src/components/PatientDetail/AssessmentProgress.tsx
@@ -15,8 +15,7 @@ import {
 } from "@mui/material";
 import withTheme from "@mui/styles/withTheme";
 import { GridCellParams, GridColDef, GridRowParams } from "@mui/x-data-grid";
-import { compareAsc, format } from "date-fns";
-import compareDesc from "date-fns/compareDesc";
+import { format } from "date-fns";
 import { action } from "mobx";
 import { observer, useLocalObservable } from "mobx-react";
 import {
@@ -81,7 +80,8 @@ export interface IAssessmentProgressProps {
   options: { text: string; value: number }[];
   maxValue: number;
   assessment: IAssessment;
-  assessmentLogs: IAssessmentLog[];
+  assessmentLogsSortedByDate: IAssessmentLog[];
+  assessmentLogsSortedByDateDescending: IAssessmentLog[];
   canAdd?: boolean;
   useTime?: boolean;
 }
@@ -99,7 +99,8 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
       options,
       assessment,
       assessmentName,
-      assessmentLogs,
+      assessmentLogsSortedByDate,
+      assessmentLogsSortedByDateDescending,
       maxValue,
       canAdd,
       useTime,
@@ -234,18 +235,15 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
 
     const questionIds = questions.map((q) => q.id);
 
-    const tableData = assessmentLogs
-      .slice()
-      .sort((a, b) => compareDesc(a.recordedDateTime, b.recordedDateTime))
-      .map((a) => {
-        return {
-          date: format(a.recordedDateTime, "MM/dd/yy"),
-          total: getAssessmentScoreFromAssessmentLog(a),
-          id: a.assessmentLogId,
-          ...a.pointValues,
-          comment: a.comment,
-        };
-      });
+    const tableData = assessmentLogsSortedByDateDescending.map((a) => {
+      return {
+        date: format(a.recordedDateTime, "MM/dd/yy"),
+        total: getAssessmentScoreFromAssessmentLog(a),
+        id: a.assessmentLogId,
+        ...a.pointValues,
+        comment: a.comment,
+      };
+    });
 
     const recurrence =
       assessment.assigned && assessment.assignedDateTime
@@ -309,7 +307,9 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
 
     const onRowClick = action((param: GridRowParams) => {
       const id = param.row["id"] as string;
-      const data = assessmentLogs.find((a) => a.assessmentLogId == id);
+      const data = assessmentLogsSortedByDate.find(
+        (a) => a.assessmentLogId == id,
+      );
       if (!!data) {
         logState.openEdit = true;
         logState.log = { ...data };
@@ -376,39 +376,36 @@ export const AssessmentProgress: FunctionComponent<IAssessmentProgressProps> =
           )}
       >
         <Grid container alignItems="stretch">
-          {assessment.assessmentId != "mood" && assessmentLogs.length > 0 && (
-            <Table
-              rows={tableData}
-              columns={columns.map((c) => ({
-                sortable: false,
-                filterable: false,
-                editable: false,
-                hideSortIcons: true,
-                disableColumnMenu: true,
-                ...c,
-              }))}
-              headerHeight={36}
-              autoHeight={true}
-              onRowClick={onRowClick}
-              isRowSelectable={() => false}
-              pagination
-            />
-          )}
-          {assessmentLogs.length > 0 && (
+          {assessment.assessmentId != "mood" &&
+            assessmentLogsSortedByDate.length > 0 && (
+              <Table
+                rows={tableData}
+                columns={columns.map((c) => ({
+                  sortable: false,
+                  filterable: false,
+                  editable: false,
+                  hideSortIcons: true,
+                  disableColumnMenu: true,
+                  ...c,
+                }))}
+                headerHeight={36}
+                autoHeight={true}
+                onRowClick={onRowClick}
+                isRowSelectable={() => false}
+                pagination
+              />
+            )}
+          {assessmentLogsSortedByDate.length > 0 && (
             <Grid item xs={12}>
               <AssessmentVis
-                data={assessmentLogs
-                  .slice()
-                  .sort((a, b) =>
-                    compareAsc(a.recordedDateTime, b.recordedDateTime),
-                  )}
+                data={assessmentLogsSortedByDate}
                 maxValue={maxValue}
                 useTime={useTime}
                 scaleOrder={questions.map((q) => q.id)}
               />
             </Grid>
           )}
-          {assessmentLogs.length == 0 && (
+          {assessmentLogsSortedByDate.length == 0 && (
             <Grid item xs={12}>
               <Typography>{`There are no ${assessmentName} scores submitted for this patient`}</Typography>
             </Grid>

--- a/web_registry/src/components/PatientDetail/ProgressInformation.tsx
+++ b/web_registry/src/components/PatientDetail/ProgressInformation.tsx
@@ -35,9 +35,14 @@ export const ProgressInformation: FunctionComponent = observer(() => {
         assigned: false,
       } as IAssessment);
 
-    const assessmentLogs = currentPatient?.assessmentLogs.filter(
-      (l) => l.assessmentId == assessmentId,
-    );
+    const assessmentLogsSortedByDate =
+      currentPatient?.assessmentLogsSortedByDate.filter(
+        (l) => l.assessmentId == assessmentId,
+      );
+    const assessmentLogsSortedByDateDescending =
+      currentPatient?.assessmentLogsSortedByDateDescending.filter(
+        (l) => l.assessmentId == assessmentId,
+      );
 
     // if (!!assessment) {
     switch (assessmentId) {
@@ -47,7 +52,10 @@ export const ProgressInformation: FunctionComponent = observer(() => {
           <Grid item xs={12} sm={12} key={assessmentId}>
             <AssessmentProgress
               assessment={assessment}
-              assessmentLogs={assessmentLogs}
+              assessmentLogsSortedByDate={assessmentLogsSortedByDate}
+              assessmentLogsSortedByDateDescending={
+                assessmentLogsSortedByDateDescending
+              }
               assessmentName={assessmentContent.name}
               instruction={assessmentContent.instruction}
               questions={assessmentContent.questions}
@@ -62,7 +70,7 @@ export const ProgressInformation: FunctionComponent = observer(() => {
           <Grid item xs={12} sm={12} key={assessmentId}>
             <MedicationProgress
               assessment={assessment}
-              assessmentLogs={assessmentLogs}
+              assessmentLogs={assessmentLogsSortedByDate}
             />
           </Grid>
         );

--- a/web_registry/src/components/PatientDetail/ProgressInformation.tsx
+++ b/web_registry/src/components/PatientDetail/ProgressInformation.tsx
@@ -35,12 +35,12 @@ export const ProgressInformation: FunctionComponent = observer(() => {
         assigned: false,
       } as IAssessment);
 
-    const assessmentLogsSortedByDate =
-      currentPatient?.assessmentLogsSortedByDate.filter(
+    const assessmentLogsSortedByDateAndTime =
+      currentPatient?.assessmentLogsSortedByDateAndTime.filter(
         (l) => l.assessmentId == assessmentId,
       );
-    const assessmentLogsSortedByDateDescending =
-      currentPatient?.assessmentLogsSortedByDateDescending.filter(
+    const assessmentLogsSortedByDateAndTimeDescending =
+      currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
         (l) => l.assessmentId == assessmentId,
       );
 
@@ -52,9 +52,9 @@ export const ProgressInformation: FunctionComponent = observer(() => {
           <Grid item xs={12} sm={12} key={assessmentId}>
             <AssessmentProgress
               assessment={assessment}
-              assessmentLogsSortedByDate={assessmentLogsSortedByDate}
+              assessmentLogsSortedByDate={assessmentLogsSortedByDateAndTime}
               assessmentLogsSortedByDateDescending={
-                assessmentLogsSortedByDateDescending
+                assessmentLogsSortedByDateAndTimeDescending
               }
               assessmentName={assessmentContent.name}
               instruction={assessmentContent.instruction}
@@ -70,7 +70,7 @@ export const ProgressInformation: FunctionComponent = observer(() => {
           <Grid item xs={12} sm={12} key={assessmentId}>
             <MedicationProgress
               assessment={assessment}
-              assessmentLogs={assessmentLogsSortedByDate}
+              assessmentLogs={assessmentLogsSortedByDateAndTime}
             />
           </Grid>
         );

--- a/web_registry/src/components/PatientDetail/TreatmentInfo.tsx
+++ b/web_registry/src/components/PatientDetail/TreatmentInfo.tsx
@@ -16,22 +16,19 @@ import { getLatestScore } from "src/utils/assessment";
 export const TreatmentInfo: FunctionComponent = observer(() => {
   const currentPatient = usePatient();
 
-  const sortedAssessmentLogs = currentPatient?.assessmentLogs
-    .slice()
-    .sort((a, b) => compareDesc(a.recordedDateTime, b.recordedDateTime));
-
-  const latestPhqLog = sortedAssessmentLogs.filter(
+  const latestPhqLog = currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
     (a) => a.assessmentId == "phq-9",
   )[0];
   const latestPhqScore = getLatestScore(
-    currentPatient?.assessmentLogs,
+    currentPatient?.assessmentLogsSortedByDateAndTimeDescending,
     "phq-9",
   );
-  const latestGadLog = sortedAssessmentLogs.filter(
+  
+  const latestGadLog = currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
     (a) => a.assessmentId == "gad-7",
   )[0];
   const latestGadScore = getLatestScore(
-    currentPatient?.assessmentLogs,
+    currentPatient?.assessmentLogsSortedByDateAndTimeDescending,
     "gad-7",
   );
 

--- a/web_registry/src/components/PatientDetail/TreatmentInfo.tsx
+++ b/web_registry/src/components/PatientDetail/TreatmentInfo.tsx
@@ -16,17 +16,19 @@ import { getLatestScore } from "src/utils/assessment";
 export const TreatmentInfo: FunctionComponent = observer(() => {
   const currentPatient = usePatient();
 
-  const latestPhqLog = currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
-    (a) => a.assessmentId == "phq-9",
-  )[0];
+  const latestPhqLog =
+    currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
+      (a) => a.assessmentId == "phq-9",
+    )[0];
   const latestPhqScore = getLatestScore(
     currentPatient?.assessmentLogsSortedByDateAndTimeDescending,
     "phq-9",
   );
-  
-  const latestGadLog = currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
-    (a) => a.assessmentId == "gad-7",
-  )[0];
+
+  const latestGadLog =
+    currentPatient?.assessmentLogsSortedByDateAndTimeDescending.filter(
+      (a) => a.assessmentId == "gad-7",
+    )[0];
   const latestGadScore = getLatestScore(
     currentPatient?.assessmentLogsSortedByDateAndTimeDescending,
     "gad-7",

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -87,6 +87,7 @@ export interface IPatientStore extends IPatient {
   getActivitiesByLifeAreaId: (lifeAreaId: string) => IActivity[];
   getActivitiesByValueId: (valueId: string) => IActivity[];
   getActivitiesWithoutValueId: () => IActivity[];
+  getAssessmentLogById: (assessmentLogId: string) => IAssessmentLog | undefined;
   getCaseReviewById: (caseReviewId: string) => ICaseReview | undefined;
   getSessionById: (sessionId: string) => ISession | undefined;
   getValueById: (valueId: string) => IValue | undefined;
@@ -497,6 +498,12 @@ export class PatientStore implements IPatientStore {
     return this.activities.filter((current) => {
       return !current.valueId;
     });
+  }
+
+  public getAssessmentLogById(assessmentLogId: string) {
+    return this.assessmentLogs.find(
+      (current) => current.assessmentLogId == assessmentLogId,
+    );
   }
 
   public getCaseReviewById(caseReviewId: string) {

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -14,7 +14,7 @@ import {
 } from "shared/patientService";
 import { IPromiseQueryState, PromiseQuery } from "shared/promiseQuery";
 import {
-  sortAssessmentLogsByDate,
+  sortAssessmentLogsByDateAndTime,
   sortCaseReviewsByDate,
   sortCaseReviewsOrSessionsByDate,
   SortDirection,
@@ -73,8 +73,8 @@ export interface IPatientStore extends IPatient {
   readonly loadValuesInventoryState: IPromiseQueryState;
 
   // Sorted properties
-  readonly assessmentLogsSortedByDate: IAssessmentLog[];
-  readonly assessmentLogsSortedByDateDescending: IAssessmentLog[];
+  readonly assessmentLogsSortedByDateAndTime: IAssessmentLog[];
+  readonly assessmentLogsSortedByDateAndTimeDescending: IAssessmentLog[];
   readonly caseReviewsSortedByDate: ICaseReview[];
   readonly caseReviewsOrSessionsSortedByDate: (ICaseReview | ISession)[];
   readonly caseReviewsOrSessionsSortedByDateDescending: (
@@ -280,12 +280,12 @@ export class PatientStore implements IPatientStore {
     return this.loadAssessmentLogsQuery.value || [];
   }
 
-  @computed get assessmentLogsSortedByDate() {
-    return sortAssessmentLogsByDate(this.assessmentLogs);
+  @computed get assessmentLogsSortedByDateAndTime() {
+    return sortAssessmentLogsByDateAndTime(this.assessmentLogs);
   }
 
-  @computed get assessmentLogsSortedByDateDescending() {
-    return sortAssessmentLogsByDate(
+  @computed get assessmentLogsSortedByDateAndTimeDescending() {
+    return sortAssessmentLogsByDateAndTime(
       this.assessmentLogs,
       SortDirection.DESCENDING,
     );

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -14,6 +14,7 @@ import {
 } from "shared/patientService";
 import { IPromiseQueryState, PromiseQuery } from "shared/promiseQuery";
 import {
+  sortAssessmentLogsByDate,
   sortCaseReviewsByDate,
   sortCaseReviewsOrSessionsByDate,
   SortDirection,
@@ -72,6 +73,8 @@ export interface IPatientStore extends IPatient {
   readonly loadValuesInventoryState: IPromiseQueryState;
 
   // Sorted properties
+  readonly assessmentLogsSortedByDate: IAssessmentLog[];
+  readonly assessmentLogsSortedByDateDescending: IAssessmentLog[];
   readonly caseReviewsSortedByDate: ICaseReview[];
   readonly caseReviewsOrSessionsSortedByDate: (ICaseReview | ISession)[];
   readonly caseReviewsOrSessionsSortedByDateDescending: (
@@ -275,6 +278,17 @@ export class PatientStore implements IPatientStore {
 
   @computed get assessmentLogs() {
     return this.loadAssessmentLogsQuery.value || [];
+  }
+
+  @computed get assessmentLogsSortedByDate() {
+    return sortAssessmentLogsByDate(this.assessmentLogs);
+  }
+
+  @computed get assessmentLogsSortedByDateDescending() {
+    return sortAssessmentLogsByDate(
+      this.assessmentLogs,
+      SortDirection.DESCENDING,
+    );
   }
 
   @computed get identity() {

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -3,6 +3,7 @@ import { toLocalDateTime } from "shared/time";
 import {
   IActivity,
   IActivitySchedule,
+  IAssessmentLog,
   ICaseReview,
   ISession,
 } from "shared/types";
@@ -42,6 +43,13 @@ export const compareActivityScheduleByDateAndTime: (
   const compareDateB = toLocalDateTime(compareB.date, compareB.timeOfDay);
 
   return compareAsc(compareDateA, compareDateB);
+};
+
+export const compareAssessmentLogsByDate: (
+  compareA: IAssessmentLog,
+  compareB: IAssessmentLog,
+) => number = function (compareA, compareB): number {
+  return compareAsc(compareA.recordedDateTime, compareB.recordedDateTime);
 };
 
 export const compareCaseReviewsByDate: (
@@ -84,6 +92,20 @@ export const sortActivitySchedulesByDateAndTime: (
   activitySchedules: IActivitySchedule[],
 ) => IActivitySchedule[] = function (activitySchedules) {
   return activitySchedules.slice().sort(compareActivityScheduleByDateAndTime);
+};
+
+export const sortAssessmentLogsByDate: (
+  assessmentLogs: IAssessmentLog[],
+  sortingDirection?: SortDirection,
+) => IAssessmentLog[] = function (
+  assessmentLogs,
+  sortingDirection = SortDirection.ASCENDING,
+) {
+  return assessmentLogs
+    .slice()
+    .sort(
+      sortingDirectionComparator(compareAssessmentLogsByDate, sortingDirection),
+    );
 };
 
 export const sortCaseReviewsByDate: (

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -104,7 +104,10 @@ export const sortAssessmentLogsByDateAndTime: (
   return assessmentLogs
     .slice()
     .sort(
-      sortingDirectionComparator(compareAssessmentLogsByDateAndTime, sortingDirection),
+      sortingDirectionComparator(
+        compareAssessmentLogsByDateAndTime,
+        sortingDirection,
+      ),
     );
 };
 

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -45,7 +45,7 @@ export const compareActivityScheduleByDateAndTime: (
   return compareAsc(compareDateA, compareDateB);
 };
 
-export const compareAssessmentLogsByDate: (
+export const compareAssessmentLogsByDateAndTime: (
   compareA: IAssessmentLog,
   compareB: IAssessmentLog,
 ) => number = function (compareA, compareB): number {
@@ -94,7 +94,7 @@ export const sortActivitySchedulesByDateAndTime: (
   return activitySchedules.slice().sort(compareActivityScheduleByDateAndTime);
 };
 
-export const sortAssessmentLogsByDate: (
+export const sortAssessmentLogsByDateAndTime: (
   assessmentLogs: IAssessmentLog[],
   sortingDirection?: SortDirection,
 ) => IAssessmentLog[] = function (
@@ -104,7 +104,7 @@ export const sortAssessmentLogsByDate: (
   return assessmentLogs
     .slice()
     .sort(
-      sortingDirectionComparator(compareAssessmentLogsByDate, sortingDirection),
+      sortingDirectionComparator(compareAssessmentLogsByDateAndTime, sortingDirection),
     );
 };
 


### PR DESCRIPTION
Utility functions for sorted assessment logs.

Existing uses of the unsorted assessment logs appear to have been correct.

Not all uses of `patientStore.assessments` have been replaced. Some views are applying complex logic, mostly due to filtering different types of assessment. Deferred to the future.