### PR TITLE
Patient Store Support to Sort Mood Logs by Date and Time

### DIFF
--- a/web_registry/src/components/PatientDetail/MoodProgress.tsx
+++ b/web_registry/src/components/PatientDetail/MoodProgress.tsx
@@ -2,8 +2,7 @@ import React, { FunctionComponent } from "react";
 
 import { Grid, Typography } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
-import { compareAsc, format } from "date-fns";
-import compareDesc from "date-fns/compareDesc";
+import { format } from "date-fns";
 import { observer } from "mobx-react";
 import { IAssessment, IMoodLog } from "shared/types";
 import ActionPanel from "src/components/common/ActionPanel";
@@ -15,7 +14,8 @@ import { usePatient, useStores } from "src/stores/stores";
 export interface IMoodProgressProps {
   assessment: IAssessment;
   maxValue: number;
-  moodLogs: IMoodLog[];
+  moodLogsSortedByDate: IMoodLog[];
+  moodLogsSortedByDateDescending: IMoodLog[];
 }
 
 export const MoodProgress: FunctionComponent<IMoodProgressProps> = observer(
@@ -23,17 +23,18 @@ export const MoodProgress: FunctionComponent<IMoodProgressProps> = observer(
     const currentPatient = usePatient();
     const rootStore = useStores();
 
-    const { moodLogs, assessment, maxValue } = props;
+    const {
+      moodLogsSortedByDate,
+      moodLogsSortedByDateDescending,
+      assessment,
+      maxValue,
+    } = props;
 
     const assessmentContent = rootStore.getAssessmentContent(
       assessment.assessmentId,
     );
 
-    const sortedMoodLogs = moodLogs
-      ?.slice()
-      .sort((a, b) => compareDesc(a.recordedDateTime, b.recordedDateTime));
-
-    const tableData = sortedMoodLogs?.map((a) => {
+    const tableData = moodLogsSortedByDateDescending?.map((a) => {
       return {
         date: format(a.recordedDateTime, "MM/dd/yy"),
         time: format(a.recordedDateTime, "hh:mm aa"),
@@ -95,7 +96,7 @@ export const MoodProgress: FunctionComponent<IMoodProgressProps> = observer(
         error={currentPatient?.loadMoodLogsState.error}
       >
         <Grid container alignItems="stretch">
-          {!!sortedMoodLogs && sortedMoodLogs.length > 0 && (
+          {!!moodLogsSortedByDate && moodLogsSortedByDate.length > 0 && (
             <Table
               rows={tableData}
               columns={columns.map((c) => ({
@@ -112,24 +113,19 @@ export const MoodProgress: FunctionComponent<IMoodProgressProps> = observer(
               pagination
             />
           )}
-          {!!sortedMoodLogs && sortedMoodLogs.length > 0 && (
+          {!!moodLogsSortedByDate && moodLogsSortedByDate.length > 0 && (
             <Grid item xs={12}>
               <AssessmentVis
-                data={moodLogs
-                  .slice()
-                  .sort((a, b) =>
-                    compareAsc(a.recordedDateTime, b.recordedDateTime),
-                  )
-                  .map((log) => ({
-                    recordedDateTime: log.recordedDateTime,
-                    pointValues: { Mood: log.mood },
-                  }))}
+                data={moodLogsSortedByDate.map((log) => ({
+                  recordedDateTime: log.recordedDateTime,
+                  pointValues: { Mood: log.mood },
+                }))}
                 maxValue={maxValue}
                 useTime={true}
               />
             </Grid>
           )}
-          {(!sortedMoodLogs || sortedMoodLogs.length == 0) && (
+          {(!moodLogsSortedByDate || moodLogsSortedByDate.length == 0) && (
             <Grid item xs={12}>
               <Typography>
                 {getString("patient_progress_mood_empty")}

--- a/web_registry/src/components/PatientDetail/ProgressInformation.tsx
+++ b/web_registry/src/components/PatientDetail/ProgressInformation.tsx
@@ -80,7 +80,10 @@ export const ProgressInformation: FunctionComponent = observer(() => {
             <MoodProgress
               assessment={assessment}
               maxValue={assessmentMax}
-              moodLogs={currentPatient?.moodLogs || []}
+              moodLogsSortedByDate={currentPatient?.moodLogsSortedByDate || []}
+              moodLogsSortedByDateDescending={
+                currentPatient?.moodLogsSortedByDateDescending || []
+              }
             />
           </Grid>
         );

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -18,6 +18,7 @@ import {
   sortCaseReviewsByDate,
   sortCaseReviewsOrSessionsByDate,
   SortDirection,
+  sortMoodLogsByDate,
   sortSessionsByDate,
 } from "shared/sorting";
 import {
@@ -82,6 +83,8 @@ export interface IPatientStore extends IPatient {
     | ISession
   )[];
   readonly sessionsSortedByDate: ISession[];
+  readonly moodLogsSortedByDate: IMoodLog[];
+  readonly moodLogsSortedByDateDescending: IMoodLog[];
 
   // Helpers
   getActivitiesByLifeAreaId: (lifeAreaId: string) => IActivity[];
@@ -303,6 +306,14 @@ export class PatientStore implements IPatientStore {
 
   @computed get moodLogs() {
     return this.loadMoodLogsQuery.value || [];
+  }
+
+  @computed get moodLogsSortedByDate() {
+    return sortMoodLogsByDate(this.moodLogs);
+  }
+
+  @computed get moodLogsSortedByDateDescending() {
+    return sortMoodLogsByDate(this.moodLogs, SortDirection.DESCENDING);
   }
 
   @computed get name() {

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -18,7 +18,7 @@ import {
   sortCaseReviewsByDate,
   sortCaseReviewsOrSessionsByDate,
   SortDirection,
-  sortMoodLogsByDate,
+  sortMoodLogsByDateAndTime,
   sortSessionsByDate,
 } from "shared/sorting";
 import {
@@ -83,8 +83,8 @@ export interface IPatientStore extends IPatient {
     | ISession
   )[];
   readonly sessionsSortedByDate: ISession[];
-  readonly moodLogsSortedByDate: IMoodLog[];
-  readonly moodLogsSortedByDateDescending: IMoodLog[];
+  readonly moodLogsSortedByDateAndTime: IMoodLog[];
+  readonly moodLogsSortedByDateAndTimeDescending: IMoodLog[];
 
   // Helpers
   getActivitiesByLifeAreaId: (lifeAreaId: string) => IActivity[];
@@ -308,12 +308,12 @@ export class PatientStore implements IPatientStore {
     return this.loadMoodLogsQuery.value || [];
   }
 
-  @computed get moodLogsSortedByDate() {
-    return sortMoodLogsByDate(this.moodLogs);
+  @computed get moodLogsSortedByDateAndTime() {
+    return sortMoodLogsByDateAndTime(this.moodLogs);
   }
 
-  @computed get moodLogsSortedByDateDescending() {
-    return sortMoodLogsByDate(this.moodLogs, SortDirection.DESCENDING);
+  @computed get moodLogsSortedByDateAndTimeDescending() {
+    return sortMoodLogsByDateAndTime(this.moodLogs, SortDirection.DESCENDING);
   }
 
   @computed get name() {

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -67,7 +67,7 @@ export const compareCaseReviewsOrSessionsByDate: (
   return compareAsc(compareA.date, compareB.date);
 };
 
-export const compareMoodLogsByDate: (
+export const compareMoodLogsByDateAndTime: (
   compareA: IMoodLog,
   compareB: IMoodLog,
 ) => number = function (compareA, compareB): number {
@@ -142,7 +142,7 @@ export const sortCaseReviewsOrSessionsByDate: (
     );
 };
 
-export const sortMoodLogsByDate: (
+export const sortMoodLogsByDateAndTime: (
   moodLogs: IMoodLog[],
   sortingDirection?: SortDirection,
 ) => IMoodLog[] = function (
@@ -151,7 +151,12 @@ export const sortMoodLogsByDate: (
 ) {
   return moodLogs
     .slice()
-    .sort(sortingDirectionComparator(compareMoodLogsByDate, sortingDirection));
+    .sort(
+      sortingDirectionComparator(
+        compareMoodLogsByDateAndTime,
+        sortingDirection,
+      ),
+    );
 };
 
 export const sortSessionsByDate: (sessions: ISession[]) => ISession[] =

--- a/web_shared/sorting.ts
+++ b/web_shared/sorting.ts
@@ -5,6 +5,7 @@ import {
   IActivitySchedule,
   IAssessmentLog,
   ICaseReview,
+  IMoodLog,
   ISession,
 } from "shared/types";
 
@@ -64,6 +65,13 @@ export const compareCaseReviewsOrSessionsByDate: (
   compareB: ICaseReview | ISession,
 ) => number = function (compareA, compareB): number {
   return compareAsc(compareA.date, compareB.date);
+};
+
+export const compareMoodLogsByDate: (
+  compareA: IMoodLog,
+  compareB: IMoodLog,
+) => number = function (compareA, compareB): number {
+  return compareAsc(compareA.recordedDateTime, compareB.recordedDateTime);
 };
 
 export const compareSessionsByDate: (
@@ -132,6 +140,18 @@ export const sortCaseReviewsOrSessionsByDate: (
         sortingDirection,
       ),
     );
+};
+
+export const sortMoodLogsByDate: (
+  moodLogs: IMoodLog[],
+  sortingDirection?: SortDirection,
+) => IMoodLog[] = function (
+  moodLogs,
+  sortingDirection = SortDirection.ASCENDING,
+) {
+  return moodLogs
+    .slice()
+    .sort(sortingDirectionComparator(compareMoodLogsByDate, sortingDirection));
 };
 
 export const sortSessionsByDate: (sessions: ISession[]) => ISession[] =


### PR DESCRIPTION
Utility functions for sorted mood logs.

Existing uses of the unsorted mood logs appear to have been correct.

Based on #497.