### PR TITLE
Provide Appropriately Ambiguous Username or Password Error Message

### DIFF
--- a/web_patient/src/components/Chrome/Login.tsx
+++ b/web_patient/src/components/Chrome/Login.tsx
@@ -155,9 +155,9 @@ const LoginForm: FunctionComponent<{
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "User does not exist."
-              ? "Username incorrect."
+              ? "Username or password incorrect."
               : error == "Incorrect username or password."
-                ? "Username incorrect."
+                ? "Username or password incorrect."
                 : error == "Password attempts exceeded"
                   ? "Username attempt limit exceeded. Try again later."
                   : error}

--- a/web_registry/src/components/chrome/Login.tsx
+++ b/web_registry/src/components/chrome/Login.tsx
@@ -155,9 +155,9 @@ const LoginForm: FunctionComponent<{
         {error && (
           <FormHelperText error={true} sx={{ lineHeight: 1 }}>
             {error == "User does not exist."
-              ? "Username incorrect."
+              ? "Username or password incorrect."
               : error == "Incorrect username or password."
-                ? "Username incorrect."
+                ? "Username or password incorrect."
                 : error == "Password attempts exceeded"
                   ? "Username attempt limit exceeded. Try again later."
                   : error}


### PR DESCRIPTION
A message of "Username incorrect." has been displayed when the actual error is in the password.

Correct to an appropriately ambiguous "Username or password incorrect.".

This fix is only at the surface. There is a separate need to explore underlying Cognito errors.