### PR TITLE
Follow-Up Due Should Highlight After 1 Month

### DIFF
--- a/web_registry/src/components/caseload/CaseloadTable.tsx
+++ b/web_registry/src/components/caseload/CaseloadTable.tsx
@@ -20,7 +20,6 @@ import {
 import {
   addWeeks,
   compareAsc,
-  differenceInDays,
   differenceInMonths,
   differenceInWeeks,
 } from "date-fns";
@@ -657,7 +656,7 @@ export const CaseloadTable: FunctionComponent<ICaseloadTableProps> = observer(
         })();
         const nextSessionOverdue =
           nextSessionDueDate &&
-          differenceInDays(todayDateUtc, nextSessionDueDate) >= 1;
+          differenceInMonths(todayDateUtc, nextSessionDueDate) >= 1;
         const initialAtRisk =
           phq9Entries &&
           phq9Entries.length > 0 &&


### PR DESCRIPTION
In the caseload overview, the yellow highlight of Follow-Up Due should not be applied until 1 month overdue.