### PR TITLE
Registry Indicator for Patient Recent Entry Cutoff

### DIFF
--- a/web_registry/src/components/PatientDetail/PatientDetailPage.tsx
+++ b/web_registry/src/components/PatientDetail/PatientDetailPage.tsx
@@ -1,7 +1,17 @@
 import React, { FunctionComponent, useEffect } from "react";
 
-import { Divider, Grid, Paper, Typography } from "@mui/material";
+// import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
+import {
+  Divider,
+  FormHelperText,
+  Grid,
+  InputLabel,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
 import withTheme from "@mui/styles/withTheme";
+import { format } from "date-fns";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import { useParams } from "react-router";
@@ -17,6 +27,12 @@ import { getString } from "src/services/strings";
 import { PatientStoreProvider, useStores } from "src/stores/stores";
 import { sortAssessmentContent } from "src/utils/assessment";
 import styled from "styled-components";
+
+const TitleContainer = withTheme(
+  styled.div((props) => ({
+    padding: props.theme.spacing(2.5, 2.5, 1, 2.5),
+  })),
+);
 
 const DetailPageContainer = withTheme(
   styled.div({
@@ -231,6 +247,53 @@ export const PatientDetailPage: FunctionComponent = observer(() => {
                 <Grid item>
                   <Divider variant="middle" />
                 </Grid>
+                {!!currentPatient.recentEntryCaseloadSummary && (
+                  <React.Fragment>
+                    <Grid item>
+                      <TitleContainer>
+                        <Stack
+                          direction={"row"}
+                          justifyContent={"space-between"}
+                        >
+                          <Stack direction={"column"}>
+                            <InputLabel>New Patient Entry</InputLabel>
+                            <FormHelperText>
+                              Since{" "}
+                              {format(
+                                currentPatient.recentEntryCutoffDateTime,
+                                "MM/dd/yyyy h:mm aaa",
+                              )}
+                            </FormHelperText>
+                            {/*
+                            <FormHelperText>
+                              Last Reviewed:
+                            </FormHelperText>
+                            <FormHelperText>
+                              {format(currentPatient.recentEntryCutoffDateTime, "MM/dd/yyyy h:mm aaa")}
+                            </FormHelperText>
+                            */}
+                          </Stack>
+                          <Stack direction={"column"} alignItems={"start"}>
+                            {/*
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              color="primary"
+                              startIcon={<AssignmentTurnedInOutlinedIcon />}
+                              // onClick={onRecentEntryMarkReviewed}
+                            >
+                              Mark Reviewed
+                            </Button>
+                            */}
+                          </Stack>
+                        </Stack>
+                      </TitleContainer>
+                    </Grid>
+                    <Grid item>
+                      <Divider variant="middle" />
+                    </Grid>
+                  </React.Fragment>
+                )}
                 <Grid item>
                   <ContentsMenu
                     contents={contentMenu}

--- a/web_registry/src/components/common/ContentsMenu.tsx
+++ b/web_registry/src/components/common/ContentsMenu.tsx
@@ -15,12 +15,6 @@ import { action, observable } from "mobx";
 import { observer } from "mobx-react";
 import styled, { CSSObject, ThemedStyledProps } from "styled-components";
 
-const TitleContainer = withTheme(
-  styled.div((props) => ({
-    padding: props.theme.spacing(2.5, 2.5, 1, 2.5),
-  })),
-);
-
 const ContentListBadge = withTheme(
   styled(Badge)(
     () =>
@@ -226,14 +220,7 @@ export const ContentsMenu: FunctionComponent<IContentsMenuProps> = observer(
       );
     };
 
-    return (
-      <div>
-        <TitleContainer>
-          <Typography variant="button">Contents</Typography>
-        </TitleContainer>
-        <List dense={true}>{contents.map(createListItem)}</List>
-      </div>
-    );
+    return <List dense={true}>{contents.map(createListItem)}</List>;
   },
 );
 


### PR DESCRIPTION
Provides an initial indication of the cutoff being used to define recent patient entry:

| Before | After |
| ----- | ----- |
| ![Screenshot 2024-07-28 at 09-04-38 SCOPE Registry](https://github.com/user-attachments/assets/5e860949-6c0b-4f01-a74f-1ca31f681698) | ![Screenshot 2024-07-28 at 08-32-06 SCOPE Registry](https://github.com/user-attachments/assets/2d1bc39f-f9cf-4513-af17-eecef4dae710) |

This lays groundwork for being able to mark new entries as reviewed, with a proposed design:

| Proposed |
| ----- |
| ![Screenshot 2024-07-28 at 08-28-36 SCOPE Registry](https://github.com/user-attachments/assets/a2484684-c80e-46b9-923e-38eda5588eac) |