### PR TITLE
Updated Registry Indicator for Patient Recent Entry Cutoff

### DIFF
--- a/web_registry/src/components/PatientDetail/PatientDetailPage.tsx
+++ b/web_registry/src/components/PatientDetail/PatientDetailPage.tsx
@@ -1,17 +1,7 @@
 import React, { FunctionComponent, useEffect } from "react";
 
-// import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
-import {
-  Divider,
-  FormHelperText,
-  Grid,
-  InputLabel,
-  Paper,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Divider, Grid, Paper, Typography } from "@mui/material";
 import withTheme from "@mui/styles/withTheme";
-import { format } from "date-fns";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import { useParams } from "react-router";
@@ -27,12 +17,6 @@ import { getString } from "src/services/strings";
 import { PatientStoreProvider, useStores } from "src/stores/stores";
 import { sortAssessmentContent } from "src/utils/assessment";
 import styled from "styled-components";
-
-const TitleContainer = withTheme(
-  styled.div((props) => ({
-    padding: props.theme.spacing(2.5, 2.5, 1, 2.5),
-  })),
-);
 
 const DetailPageContainer = withTheme(
   styled.div({
@@ -247,57 +231,16 @@ export const PatientDetailPage: FunctionComponent = observer(() => {
                 <Grid item>
                   <Divider variant="middle" />
                 </Grid>
-                {!!currentPatient.recentEntryCaseloadSummary && (
-                  <React.Fragment>
-                    <Grid item>
-                      <TitleContainer>
-                        <Stack
-                          direction={"row"}
-                          justifyContent={"space-between"}
-                        >
-                          <Stack direction={"column"}>
-                            <InputLabel>New Patient Entry</InputLabel>
-                            <FormHelperText>
-                              Since{" "}
-                              {format(
-                                currentPatient.recentEntryCutoffDateTime,
-                                "MM/dd/yyyy h:mm aaa",
-                              )}
-                            </FormHelperText>
-                            {/*
-                            <FormHelperText>
-                              Last Reviewed:
-                            </FormHelperText>
-                            <FormHelperText>
-                              {format(currentPatient.recentEntryCutoffDateTime, "MM/dd/yyyy h:mm aaa")}
-                            </FormHelperText>
-                            */}
-                          </Stack>
-                          <Stack direction={"column"} alignItems={"start"}>
-                            {/*
-                            <Button
-                              variant="outlined"
-                              size="small"
-                              color="primary"
-                              startIcon={<AssignmentTurnedInOutlinedIcon />}
-                              // onClick={onRecentEntryMarkReviewed}
-                            >
-                              Mark Reviewed
-                            </Button>
-                            */}
-                          </Stack>
-                        </Stack>
-                      </TitleContainer>
-                    </Grid>
-                    <Grid item>
-                      <Divider variant="middle" />
-                    </Grid>
-                  </React.Fragment>
-                )}
                 <Grid item>
                   <ContentsMenu
                     contents={contentMenu}
                     contentId="#scroll-content"
+                    recentEntryCutoffDateTime={
+                      currentPatient.recentEntryCutoffDateTime
+                    }
+                    recentEntryBadgeContent={
+                      currentPatient.recentEntryCaseloadSummary
+                    }
                   />
                 </Grid>
               </Grid>

--- a/web_registry/src/components/common/ContentsMenu.tsx
+++ b/web_registry/src/components/common/ContentsMenu.tsx
@@ -273,6 +273,7 @@ export const ContentsMenu: FunctionComponent<IContentsMenuProps> = observer(
     //             variant="outlined"
     //             size="small"
     //             color="primary"
+    //             disabled={!recentEntryBadgeContent}
     //             startIcon={<AssignmentTurnedInOutlinedIcon />}
     //             // onClick={onRecentEntryMarkReviewed}
     //           >

--- a/web_registry/src/components/common/ContentsMenu.tsx
+++ b/web_registry/src/components/common/ContentsMenu.tsx
@@ -1,19 +1,30 @@
 import React, { FunctionComponent } from "react";
 
+// import AssignmentTurnedInOutlinedIcon from "@mui/icons-material/AssignmentTurnedInOutlined";
 import {
   Badge,
+  // Button,
+  FormHelperText,
   List,
   ListItem,
   ListItemProps,
   ListItemText,
+  Stack,
   Typography,
   useTheme,
 } from "@mui/material";
 import withTheme from "@mui/styles/withTheme";
+import { format } from "date-fns";
 import throttle from "lodash.throttle";
 import { action, observable } from "mobx";
 import { observer } from "mobx-react";
 import styled, { CSSObject, ThemedStyledProps } from "styled-components";
+
+const TitleContainer = withTheme(
+  styled.div((props) => ({
+    padding: props.theme.spacing(2.5, 2.5, 1, 2.5),
+  })),
+);
 
 const ContentListBadge = withTheme(
   styled(Badge)(
@@ -58,6 +69,8 @@ export interface IContentItem {
 export interface IContentsMenuProps {
   contents: IContentItem[];
   contentId: string;
+  recentEntryCutoffDateTime: Date;
+  recentEntryBadgeContent: React.ReactNode;
 }
 
 const noop = () => {};
@@ -103,7 +116,12 @@ type ContentMenuItem = IContentItem & { node: HTMLElement | null };
 
 export const ContentsMenu: FunctionComponent<IContentsMenuProps> = observer(
   (props) => {
-    const { contents, contentId } = props;
+    const {
+      contents,
+      contentId,
+      recentEntryCutoffDateTime,
+      recentEntryBadgeContent,
+    } = props;
     const theme = useTheme();
 
     const itemsClientRef = React.useRef<ContentMenuItem[]>([]);
@@ -220,7 +238,52 @@ export const ContentsMenu: FunctionComponent<IContentsMenuProps> = observer(
       );
     };
 
-    return <List dense={true}>{contents.map(createListItem)}</List>;
+    return (
+      <div>
+        <TitleContainer>
+          <Stack direction={"column"}>
+            <Typography>CONTENTS</Typography>
+            {!!recentEntryBadgeContent && (
+              <FormHelperText>
+                New Since:
+                <br />
+                {format(recentEntryCutoffDateTime, "MM/dd/yyyy h:mm aaa")}
+              </FormHelperText>
+            )}
+          </Stack>
+        </TitleContainer>
+        <List dense={true}>{contents.map(createListItem)}</List>
+      </div>
+    );
+
+    // return (
+    //   <div>
+    //     <TitleContainer>
+    //       <Stack direction={"row"} justifyContent={"space-between"}>
+    //         <Stack direction={"column"} alignItems={"start"}>
+    //           <Typography>CONTENTS</Typography>
+    //           <FormHelperText>
+    //             Last Reviewed:
+    //             <br />
+    //             {format(recentEntryCutoffDateTime, "MM/dd/yyyy h:mm aaa")}
+    //           </FormHelperText>
+    //         </Stack>
+    //         <Stack direction={"column"} alignItems={"start"}>
+    //           <Button
+    //             variant="outlined"
+    //             size="small"
+    //             color="primary"
+    //             startIcon={<AssignmentTurnedInOutlinedIcon />}
+    //             // onClick={onRecentEntryMarkReviewed}
+    //           >
+    //             Mark Reviewed
+    //           </Button>
+    //         </Stack>
+    //       </Stack>
+    //     </TitleContainer>
+    //     <List dense={true}>{contents.map(createListItem)}</List>
+    //   </div>
+    // );
   },
 );
 

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -462,11 +462,11 @@ export class PatientStore implements IPatientStore {
       !!this.recentEntrySafetyPlan ||
       (!!this.recentEntryValues && this.recentEntryValues.length > 0);
 
-      //
-      // These currently do not render, so should not be included in determining "New"
-      //
-      // (!!this.recentEntryScheduledActivitiesSortedByDateAndTimeDescending &&
-      //   this.recentEntryScheduledActivitiesSortedByDateAndTimeDescending.length > 0) ||
+    //
+    // These currently do not render, so should not be included in determining "New"
+    //
+    // (!!this.recentEntryScheduledActivitiesSortedByDateAndTimeDescending &&
+    //   this.recentEntryScheduledActivitiesSortedByDateAndTimeDescending.length > 0) ||
 
     return recentEntry ? "New" : undefined;
   }


### PR DESCRIPTION
This improves upon and replaces the design that was in:

- #526

| With Recent Entry | Without Recent Entry |
| ----- | ----- |
| ![Screenshot 2024-07-29 at 18-45-18 SCOPE Registry](https://github.com/user-attachments/assets/3a56e93e-abc5-48f5-99a3-99139087fbe5) | ![Screenshot 2024-07-29 at 18-45-41 SCOPE Registry](https://github.com/user-attachments/assets/dd957e2c-d5b3-47dd-88b8-d3aba35fc6c3) |

Also includes updates for proposed designs:

| Proposed With Recent Entry | Proposed Without Recent Entry |
| ----- | ----- |
| ![Screenshot 2024-07-29 at 18-51-22 SCOPE Registry](https://github.com/user-attachments/assets/b2fec0e8-3d6e-4603-9ff1-22628d2fbc20) | ![Screenshot 2024-07-29 at 18-52-49 SCOPE Registry](https://github.com/user-attachments/assets/125f3ae3-55ad-442d-9bc0-9e563011c29b) |

