### PR TITLE
Remove Provider-Submitted Assessments from Recent Patient Activity Indicators

### DIFF
--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -505,9 +505,14 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryAssessmentLogsSortedByDateAndTimeDescending() {
-    const indexEnd = this.assessmentLogsSortedByDateAndTimeDescending.findIndex(
-      (a) => a.recordedDateTime < this.recentEntryCutoffDateTime,
-    );
+    const indexEnd = this.assessmentLogsSortedByDateAndTimeDescending
+      .filter((current) => {
+        if (!!current.submittedByProviderId) {
+          return false;
+        }
+        return true;
+      })
+      .findIndex((a) => a.recordedDateTime < this.recentEntryCutoffDateTime);
 
     if (indexEnd < 0) {
       return this.assessmentLogsSortedByDateAndTimeDescending.slice();

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -505,25 +505,26 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryAssessmentLogsSortedByDateAndTimeDescending() {
-    const indexEnd = this.assessmentLogsSortedByDateAndTimeDescending
-      .filter((current) => {
     // Assessments submitted by a provider are not considered recent
+    const filteredAssessmentLogs =
+      this.assessmentLogsSortedByDateAndTimeDescending.filter((current) => {
         if (!!current.submittedByProviderId) {
           return false;
         }
         return true;
-      })
-      .findIndex((a) => a.recordedDateTime < this.recentEntryCutoffDateTime);
+      });
+
+    const indexEnd = filteredAssessmentLogs.findIndex(
+      (a) => a.recordedDateTime < this.recentEntryCutoffDateTime,
+    );
 
     if (indexEnd < 0) {
-      return this.assessmentLogsSortedByDateAndTimeDescending.slice();
+      // No need to make a copy, it's already a copy.
+      return filteredAssessmentLogs;
     } else if (indexEnd === 0) {
       return undefined;
     } else {
-      return this.assessmentLogsSortedByDateAndTimeDescending.slice(
-        0,
-        indexEnd,
-      );
+      return filteredAssessmentLogs.slice(0, indexEnd);
     }
   }
 

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -507,6 +507,7 @@ export class PatientStore implements IPatientStore {
   @computed get recentEntryAssessmentLogsSortedByDateAndTimeDescending() {
     const indexEnd = this.assessmentLogsSortedByDateAndTimeDescending
       .filter((current) => {
+    // Assessments submitted by a provider are not considered recent
         if (!!current.submittedByProviderId) {
           return false;
         }


### PR DESCRIPTION
Assessments entered by a provider on behalf of a patient are not considered a recent entry and therefore "new".

The original implementation considered all assessments as potentially "new". This updates the patient store's calculation of `recentEntryAssessmentLogsSortedByDateAndTimeDescending` to filter on the presence of `submittedByProviderId`.