### PR TITLE
Allow Recent Entry Cutoff to be Undefined

### DIFF
--- a/web_registry/src/components/common/ContentsMenu.tsx
+++ b/web_registry/src/components/common/ContentsMenu.tsx
@@ -69,7 +69,7 @@ export interface IContentItem {
 export interface IContentsMenuProps {
   contents: IContentItem[];
   contentId: string;
-  recentEntryCutoffDateTime: Date;
+  recentEntryCutoffDateTime: Date | undefined;
   recentEntryBadgeContent: React.ReactNode;
 }
 
@@ -243,7 +243,7 @@ export const ContentsMenu: FunctionComponent<IContentsMenuProps> = observer(
         <TitleContainer>
           <Stack direction={"column"}>
             <Typography>CONTENTS</Typography>
-            {!!recentEntryBadgeContent && (
+            {!!recentEntryCutoffDateTime && !!recentEntryBadgeContent && (
               <FormHelperText>
                 New Since:
                 <br />

--- a/web_registry/src/stores/PatientStore.ts
+++ b/web_registry/src/stores/PatientStore.ts
@@ -476,25 +476,35 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryActivities() {
-    if (this.activities.length === 0) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (this.activities.length === 0 || !recentEntryCutoffDateTime) {
+      return undefined;
+    }
+
+    const filteredActivities = this.activities.filter(
+      (a) => a.editedDateTime >= recentEntryCutoffDateTime,
+    );
+
+    if (filteredActivities.length === 0) {
       return undefined;
     } else {
-      return this.activities.filter((a) => {
-        return (
-          this.recentEntryCutoffDateTime &&
-          a.editedDateTime >= this.recentEntryCutoffDateTime
-        );
-      });
+      return filteredActivities;
     }
   }
 
   @computed get recentEntryActivityLogsSortedByDateAndTimeDescending() {
-    if (!this.recentEntryCutoffDateTime) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (
+      this.activityLogsSortedByDateAndTimeDescending.length === 0 ||
+      !recentEntryCutoffDateTime
+    ) {
       return undefined;
     }
 
     const indexEnd = this.activityLogsSortedByDateAndTimeDescending.findIndex(
-      (a) => a.recordedDateTime < this.recentEntryCutoffDateTime!,
+      (a) => a.recordedDateTime < recentEntryCutoffDateTime,
     );
 
     if (indexEnd < 0) {
@@ -507,21 +517,23 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryAssessmentLogsSortedByDateAndTimeDescending() {
-    if (!this.recentEntryCutoffDateTime) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (
+      this.assessmentLogsSortedByDateAndTimeDescending.length === 0 ||
+      !recentEntryCutoffDateTime
+    ) {
       return undefined;
     }
 
     // Assessments submitted by a provider are not considered recent
     const filteredAssessmentLogs =
-      this.assessmentLogsSortedByDateAndTimeDescending.filter((current) => {
-        if (!!current.submittedByProviderId) {
-          return false;
-        }
-        return true;
-      });
+      this.assessmentLogsSortedByDateAndTimeDescending.filter(
+        (current) => !current.submittedByProviderId,
+      );
 
     const indexEnd = filteredAssessmentLogs.findIndex(
-      (a) => a.recordedDateTime < this.recentEntryCutoffDateTime!,
+      (a) => a.recordedDateTime < recentEntryCutoffDateTime,
     );
 
     if (indexEnd < 0) {
@@ -535,12 +547,17 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryMoodLogsSortedByDateAndTimeDescending() {
-    if (!this.recentEntryCutoffDateTime) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (
+      this.moodLogsSortedByDateAndTimeDescending.length === 0 ||
+      !recentEntryCutoffDateTime
+    ) {
       return undefined;
     }
 
     const indexEnd = this.moodLogsSortedByDateAndTimeDescending.findIndex(
-      (a) => a.recordedDateTime < this.recentEntryCutoffDateTime!,
+      (a) => a.recordedDateTime < recentEntryCutoffDateTime,
     );
 
     if (indexEnd < 0) {
@@ -553,13 +570,16 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntrySafetyPlan() {
-    if (!this.recentEntryCutoffDateTime) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (!recentEntryCutoffDateTime) {
       return undefined;
     }
+
     // The default empty safety plan will not have a lastUpdatedDateTime
     if (
       !!this.safetyPlan.lastUpdatedDateTime &&
-      this.safetyPlan.lastUpdatedDateTime >= this.recentEntryCutoffDateTime
+      this.safetyPlan.lastUpdatedDateTime >= recentEntryCutoffDateTime
     ) {
       return this.safetyPlan;
     }
@@ -567,13 +587,18 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryScheduledActivitiesSortedByDateAndTimeDescending() {
-    if (!this.recentEntryCutoffDateTime) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (
+      this.scheduledActivitiesSortedByDateAndTimeDescending.length === 0 ||
+      !recentEntryCutoffDateTime
+    ) {
       return undefined;
     }
 
     const indexEnd =
       this.scheduledActivitiesSortedByDateAndTimeDescending.findIndex(
-        (a) => a.dueDateTime < this.recentEntryCutoffDateTime!,
+        (a) => a.dueDateTime < recentEntryCutoffDateTime,
       );
 
     if (indexEnd < 0) {
@@ -589,16 +614,20 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed get recentEntryValues() {
-    if (!this.recentEntryCutoffDateTime) {
+    const recentEntryCutoffDateTime = this.recentEntryCutoffDateTime;
+
+    if (this.values.length === 0 || !recentEntryCutoffDateTime) {
       return undefined;
     }
 
-    if (this.values.length === 0) {
+    const filteredValues = this.values.filter(
+      (a) => a.editedDateTime >= recentEntryCutoffDateTime,
+    );
+
+    if (filteredValues.length === 0) {
       return undefined;
     } else {
-      return this.values.filter((a) => {
-        return a.editedDateTime >= this.recentEntryCutoffDateTime!;
-      });
+      return filteredValues;
     }
   }
 

--- a/web_shared/guards.ts
+++ b/web_shared/guards.ts
@@ -1,0 +1,20 @@
+import { ok as assert } from "assert";
+
+export function assertNotNull<T>(
+  arg: T,
+): asserts arg is Exclude<T, null | undefined> {
+  assert(arg !== null, "Invalid null");
+}
+
+export function assertNotUndefined<T>(
+  arg: T,
+): asserts arg is Exclude<T, undefined> {
+  assert(arg !== undefined, "Invalid undefined");
+}
+
+export function assertNotNullNotUndefined<T>(
+  arg: T,
+): asserts arg is Exclude<T, null | undefined> {
+  assertNotNull(arg);
+  assertNotUndefined(arg);
+}


### PR DESCRIPTION
When the definition of recent entry was based only on the current date/time, it was never undefined.

When it is based on stored documents, we need to allow/support that it may be undefined.

This is a step toward calculating the cutoff from marks, from a patient's enrollment date, or it being undefined.