### PR TITLE
 Create an Empty Recent Entry Mark for Newly-Created Patients

### DIFF
--- a/scope_shared/scope/database/patients.py
+++ b/scope_shared/scope/database/patients.py
@@ -170,9 +170,9 @@ def ensure_patient_documents(
     Any more complex or meaningful document creation should instead be configured in a populate script.
     """
 
-    # Many documents have a required assignment datetime.
+    # Many documents have a required datetime associated with their creation.
     # Generate a single value to consistently use as necessary
-    datetime_assigned = scope.database.date_utils.format_datetime(
+    datetime_created = scope.database.date_utils.format_datetime(
         pytz.utc.localize(datetime.datetime.utcnow())
     )
 
@@ -218,7 +218,7 @@ def ensure_patient_documents(
         safety_plan_document = {
             "_type": scope.database.patient.safety_plan.DOCUMENT_TYPE,
             "assigned": False,
-            "assignedDateTime": datetime_assigned,
+            "assignedDateTime": datetime_created,
         }
         result = scope.database.patient.safety_plan.put_safety_plan(
             collection=patient_collection,
@@ -235,7 +235,7 @@ def ensure_patient_documents(
         values_inventory_document = {
             "_type": scope.database.patient.values_inventory.DOCUMENT_TYPE,
             "assigned": False,
-            "assignedDateTime": datetime_assigned,
+            "assignedDateTime": datetime_created,
         }
         result = scope.database.patient.values_inventory.put_values_inventory(
             collection=patient_collection,
@@ -258,7 +258,7 @@ def ensure_patient_documents(
                 "_set_id": assessment_current,
                 scope.database.patient.assessments.SEMANTIC_SET_ID: assessment_current,
                 "assigned": False,
-                "assignedDateTime": datetime_assigned,
+                "assignedDateTime": datetime_created,
             }
             result = scope.database.patient.assessments.put_assessment(
                 collection=patient_collection,
@@ -273,7 +273,7 @@ def ensure_patient_documents(
     if not review_mark_documents:
         review_mark_document = {
             "_type": scope.database.patient.review_marks.DOCUMENT_TYPE,
-            "editedDateTime": datetime_assigned,
+            "editedDateTime": datetime_created,
         }
         result = scope.database.patient.review_marks.post_review_mark(
             collection=patient_collection,

--- a/scope_shared/scope/database/patients.py
+++ b/scope_shared/scope/database/patients.py
@@ -8,6 +8,7 @@ import scope.database.collection_utils
 import scope.database.patient.assessments
 import scope.database.patient.clinical_history
 import scope.database.patient.patient_profile
+import scope.database.patient.review_marks
 import scope.database.patient.safety_plan
 import scope.database.patient.values_inventory
 import scope.enums
@@ -264,6 +265,20 @@ def ensure_patient_documents(
                 set_id=assessment_current,
                 assessment=assessment_document,
             )
+
+    # Default review mark
+    review_mark_documents = scope.database.patient.review_marks.get_review_marks(
+        collection=patient_collection,
+    )
+    if not review_mark_documents:
+        review_mark_document = {
+            "_type": scope.database.patient.review_marks.DOCUMENT_TYPE,
+            "editedDateTime": datetime_assigned,
+        }
+        result = scope.database.patient.review_marks.post_review_mark(
+            collection=patient_collection,
+            review_mark=review_mark_document,
+        )
 
 
 def ensure_patient_identity(

--- a/scope_shared/scope/populate/patient/rule_populate_default_data.py
+++ b/scope_shared/scope/populate/patient/rule_populate_default_data.py
@@ -1,10 +1,6 @@
-import datetime
 import pymongo.database
-import pytz
 from typing import List, Optional
 
-import scope.database.date_utils as date_utils
-import scope.database.patient.review_marks
 import scope.database.patients
 from scope.populate.types import PopulateAction, PopulateContext, PopulateRule
 
@@ -106,22 +102,3 @@ def _populate_default_data(
 
     # Default population is currently None.
     # Rule left in place for future use.
-
-    def _review_mark():
-        ################################################################################
-        # Store an empty reviwe mark.
-        # - Create an empty mark so new patients that have never been marked will show data back to enrollment.
-        ################################################################################
-        review_mark = {
-            "_type": scope.database.patient.review_marks.DOCUMENT_TYPE,
-            "editedDateTime": date_utils.format_datetime(
-                pytz.utc.localize(datetime.datetime.utcnow())
-            ),
-        }
-
-        scope.database.patient.review_marks.post_review_mark(
-            collection=patient_collection,
-            review_mark=review_mark,
-        )
-
-    _review_mark()

--- a/scope_shared/scope/populate/patient/rule_populate_default_data.py
+++ b/scope_shared/scope/populate/patient/rule_populate_default_data.py
@@ -1,8 +1,15 @@
+import datetime
+import faker as _faker
 import pymongo.database
+import pytz
 from typing import List, Optional
 
+import scope.database.date_utils as date_utils
+import scope.database.patient.review_marks
 import scope.database.patients
 from scope.populate.types import PopulateAction, PopulateContext, PopulateRule
+import scope.testing.fake_data.fixtures_fake_review_mark
+
 
 ACTION_NAME = "populate_default_data"
 
@@ -70,6 +77,7 @@ class _PopulateDefaultDataAction(PopulateAction):
         # Perform the populate
         _populate_default_data(
             database=populate_context.database,
+            faker=populate_context.faker,
             patient_config=patient_config,
         )
 
@@ -79,6 +87,7 @@ class _PopulateDefaultDataAction(PopulateAction):
 def _populate_default_data(
     *,
     database: pymongo.database.Database,
+    faker: _faker.Faker,
     patient_config: dict,
 ) -> None:
     """
@@ -101,3 +110,31 @@ def _populate_default_data(
 
     # Default population is currently None.
     # Rule left in place for future use.
+
+    def _review_mark():
+        # Obtain a fake review mark
+        fake_review_mark_factory = (
+            scope.testing.fake_data.fixtures_fake_review_mark.fake_review_mark_factory(
+                faker_factory=faker
+            )
+        )
+        fake_review_mark = fake_review_mark_factory()
+        if "effectiveDateTime" in fake_review_mark:
+            del fake_review_mark["effectiveDateTime"]
+        if "providerId" in fake_review_mark:
+            del fake_review_mark["providerId"]
+
+        fake_review_mark.update(
+            {
+                "editedDateTime": date_utils.format_datetime(
+                    pytz.utc.localize(datetime.datetime.utcnow())
+                ),
+            }
+        )
+
+        scope.database.patient.review_marks.post_review_mark(
+            collection=patient_collection,
+            review_mark=fake_review_mark,
+        )
+
+    _review_mark()

--- a/scope_shared/scope/populate/patient/rule_populate_default_data.py
+++ b/scope_shared/scope/populate/patient/rule_populate_default_data.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 import scope.database.patients
 from scope.populate.types import PopulateAction, PopulateContext, PopulateRule
 
-
 ACTION_NAME = "populate_default_data"
 
 

--- a/scope_shared/scope/schemas/documents/review-mark.json
+++ b/scope_shared/scope/schemas/documents/review-mark.json
@@ -31,5 +31,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["_type", "editedDateTime", "providerId"]
+  "required": ["_type", "editedDateTime"]
 }

--- a/scope_shared/scope/testing/fake_data/fixtures_fake_review_mark.py
+++ b/scope_shared/scope/testing/fake_data/fixtures_fake_review_mark.py
@@ -9,6 +9,12 @@ import scope.database.patient.review_marks
 import scope.enums
 import scope.schema
 import scope.schema_utils
+import scope.testing.fake_data.fake_utils as fake_utils
+
+OPTIONAL_KEYS = [
+    "effectiveDateTime",
+    "providerId",
+]
 
 
 def fake_review_mark_factory(
@@ -43,6 +49,12 @@ def fake_review_mark_factory(
             # TODO: this should be a providerId
             "providerId": faker_factory.name(),
         }
+
+        # Remove a randomly sampled subset of optional parameters.
+        fake_review_mark = fake_utils.fake_optional(
+            document=fake_review_mark,
+            optional_keys=OPTIONAL_KEYS,
+        )
 
         return fake_review_mark
 

--- a/web_shared/types.ts
+++ b/web_shared/types.ts
@@ -241,7 +241,7 @@ export interface IReviewMark {
   // ID of the provider that submitted the mark
   // If these became more common, it would be necessary to decide
   // on a meaning for "providerId" versus "submittedByProviderId".
-  providerId: string;
+  providerId?: string;
 }
 
 export interface ISafetyPlan {


### PR DESCRIPTION
Newly-created patients will be created with an empty `reviewMark`. This ensures that new patients will initially show any data since enrollment as "new". We decided upon this after the deployment of v0.18.0.

Fixes #537, except we took a different approach than was initially sketched there. We included this in `ensure_patient_documents` (i.e., rather than in a populate script) so it would automatically happen if patient creation later moves out of populate scripts (e.g., in a self-deployed version of this).

#540 documents an ongoing need to be sensitive to this change in any future data migration.