### PR TITLE
Fix Chronological Sort of Assessments in Registry Session Table Visualization 

### DIFF
--- a/web_registry/src/components/PatientDetail/SessionInfo.tsx
+++ b/web_registry/src/components/PatientDetail/SessionInfo.tsx
@@ -508,7 +508,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
     });
   });
 
-  const phqScores = currentPatient.assessmentLogs
+  const phqScores = currentPatient.assessmentLogsSortedByDateAndTime
     .filter((log) => log.assessmentId == "phq-9")
     .map((log) => ({
       date: log.recordedDateTime,
@@ -516,7 +516,7 @@ export const SessionInfo: FunctionComponent = observer(() => {
         log.totalScore || getAssessmentScoreFromPointValues(log.pointValues),
     }));
 
-  const gadScores = currentPatient.assessmentLogs
+  const gadScores = currentPatient.assessmentLogsSortedByDateAndTime
     .filter((log) => log.assessmentId == "gad-7")
     .map((log) => ({
       date: log.recordedDateTime,


### PR DESCRIPTION
Fixes a bug where the registry visualization of assessments was not using the sorted assessments:

| Before |
| ----- |
| ![353204054-0352d271-b025-4dbf-b737-3dc73e5dc038](https://github.com/user-attachments/assets/700e2726-4a18-4cb9-b3ee-1d2440c26dd0) |

| After |
| ----- |
| ![image](https://github.com/user-attachments/assets/3940018e-7a54-4123-a832-b31e7e928474) |

Fixes #289, which has more history on the bug.