### PR TITLE
Extend Scheduled Items Length to 9 Months

### DIFF
--- a/scope_shared/scope/database/patient/activity_schedules.py
+++ b/scope_shared/scope/database/patient/activity_schedules.py
@@ -29,7 +29,8 @@ def _calculate_scheduled_activities_to_create(
 
     if activity_schedule["hasRepetition"]:
         frequency = scope.enums.ScheduledItemFrequency.Weekly.value
-        months = 3
+        # Changed to 9 months on 7/31/2025, based on remaining study length
+        months = 9
         repeat_day_flags = activity_schedule["repeatDayFlags"]
     else:
         frequency = None

--- a/scope_shared/scope/database/patient/assessments.py
+++ b/scope_shared/scope/database/patient/assessments.py
@@ -40,7 +40,8 @@ def _calculate_scheduled_assessments_to_create(
         reminder=True,
         reminder_time_of_day=8,
         timezone=timezone,
-        months=3,
+        # Changed to 9 months on 7/31/2025, based on remaining study length
+        months=9,
     )
 
     # Fill in additional data needed for scheduled assessments


### PR DESCRIPTION
Based on realization this was still set to 3 months, update to 9 months (i.e., end of study period).