### PR TITLE
Fix Calculation of What Scheduled Assessments are Currently Due

### DIFF
--- a/scope_shared/scope/tasks/extend_schedules.py
+++ b/scope_shared/scope/tasks/extend_schedules.py
@@ -40,7 +40,6 @@ import scope.enums
 import scope.populate
 import scope.schema
 import scope.schema_utils
-import scope.utils.compute_patient_summary
 
 
 class ScopeInstanceId(Enum):

--- a/scope_shared/scope/tasks/notifications.py
+++ b/scope_shared/scope/tasks/notifications.py
@@ -23,6 +23,7 @@ import scope.database.document_utils
 import scope.database.initialize
 import scope.database.patient
 import scope.database.patient.activities
+import scope.database.patient.assessment_logs
 import scope.database.patient.safety_plan
 import scope.database.patient.scheduled_activities
 import scope.database.patient.scheduled_assessments
@@ -239,6 +240,11 @@ def _content_patient_summary(
         match_deleted=False,
     ).documents
 
+    assessment_log_documents = current_document_set.filter_match(
+        match_type=scope.database.patient.assessment_logs.DOCUMENT_TYPE,
+        match_deleted=False,
+    ).documents
+
     safety_plan_document = current_document_set.filter_match(
         match_type=scope.database.patient.safety_plan.DOCUMENT_TYPE,
         match_deleted=False,
@@ -256,6 +262,7 @@ def _content_patient_summary(
 
     patient_summary = scope.utils.compute_patient_summary.compute_patient_summary(
         activity_documents=activity_documents,
+        assessment_log_documents=assessment_log_documents,
         safety_plan_document=safety_plan_document,
         scheduled_assessment_documents=scheduled_assessment_documents,
         values_inventory_document=values_inventory_document,

--- a/scope_shared/scope/testing/test_database/test_activity_schedule_maintains_scheduled_activities.py
+++ b/scope_shared/scope/testing/test_database/test_activity_schedule_maintains_scheduled_activities.py
@@ -67,7 +67,34 @@ def test_activity_schedule_calculate_scheduled_activities_to_create():
         ]
     )
     scheduled_dates.extend(
-        [datetime.date(2022, 6, day) for day in list([6, 7, 13, 14])]
+        [datetime.date(2022, 6, day) for day in list([6, 7, 13, 14, 20, 21, 27, 28])]
+    )
+    scheduled_dates.extend(
+        [datetime.date(2022, 7, day) for day in list([4, 5, 11, 12, 18, 19, 25, 26])]
+    )
+    scheduled_dates.extend(
+        [
+            datetime.date(2022, 8, day)
+            for day in list([1, 2, 8, 9, 15, 16, 22, 23, 29, 30])
+        ]
+    )
+    scheduled_dates.extend(
+        [datetime.date(2022, 9, day) for day in list([5, 6, 12, 13, 19, 20, 26, 27])]
+    )
+    scheduled_dates.extend(
+        [
+            datetime.date(2022, 10, day)
+            for day in list([3, 4, 10, 11, 17, 18, 24, 25, 31])
+        ]
+    )
+    scheduled_dates.extend(
+        [
+            datetime.date(2022, 11, day)
+            for day in list([1, 7, 8, 14, 15, 21, 22, 28, 29])
+        ]
+    )
+    scheduled_dates.extend(
+        [datetime.date(2022, 12, day) for day in list([5, 6, 12, 13])]
     )
 
     assert scheduled_activities == [
@@ -83,7 +110,13 @@ def test_activity_schedule_calculate_scheduled_activities_to_create():
                         scheduled_date_current.year,
                         scheduled_date_current.month,
                         scheduled_date_current.day,
-                        15,
+                        15
+                        if (scheduled_date_current.month < 11)
+                        or (
+                            scheduled_date_current.month == 11
+                            and scheduled_date_current.day < 6
+                        )
+                        else 16,
                     )
                 )
             ),

--- a/scope_shared/scope/testing/test_database/test_assessment_maintains_scheduled_assessments.py
+++ b/scope_shared/scope/testing/test_database/test_assessment_maintains_scheduled_assessments.py
@@ -36,7 +36,13 @@ def test_assessment_calculate_scheduled_assessments_to_create():
     scheduled_dates.extend([datetime.date(2022, 3, day) for day in range(14, 31 + 1)])
     scheduled_dates.extend([datetime.date(2022, 4, day) for day in range(1, 30 + 1)])
     scheduled_dates.extend([datetime.date(2022, 5, day) for day in range(1, 31 + 1)])
-    scheduled_dates.extend([datetime.date(2022, 6, day) for day in range(1, 14 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 6, day) for day in range(1, 30 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 7, day) for day in range(1, 31 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 8, day) for day in range(1, 31 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 9, day) for day in range(1, 30 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 10, day) for day in range(1, 31 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 11, day) for day in range(1, 30 + 1)])
+    scheduled_dates.extend([datetime.date(2022, 12, day) for day in range(1, 14 + 1)])
 
     assert scheduled_assessments == [
         {
@@ -51,7 +57,13 @@ def test_assessment_calculate_scheduled_assessments_to_create():
                         scheduled_date_current.year,
                         scheduled_date_current.month,
                         scheduled_date_current.day,
-                        15,
+                        15
+                        if (scheduled_date_current.month < 11)
+                        or (
+                            scheduled_date_current.month == 11
+                            and scheduled_date_current.day < 6
+                        )
+                        else 16,
                     )
                 )
             ),
@@ -63,7 +75,13 @@ def test_assessment_calculate_scheduled_assessments_to_create():
                         scheduled_date_current.year,
                         scheduled_date_current.month,
                         scheduled_date_current.day,
-                        15,
+                        15
+                        if (scheduled_date_current.month < 11)
+                        or (
+                            scheduled_date_current.month == 11
+                            and scheduled_date_current.day < 6
+                        )
+                        else 16,
                     )
                 )
             ),

--- a/scope_shared/scope/utils/compute_patient_summary.py
+++ b/scope_shared/scope/utils/compute_patient_summary.py
@@ -3,7 +3,7 @@ Used in server_flask/blueprints/patient/summary.py
 
 Placed in utils so that reminder calculations can also use.
 """
-
+import copy
 import datetime
 from typing import List
 
@@ -11,7 +11,9 @@ import scope.database.date_utils as date_utils
 
 
 def compute_patient_summary(
+    *,
     activity_documents: List[dict],
+    assessment_log_documents: List[dict],
     safety_plan_document: dict,
     scheduled_assessment_documents: List[dict],
     values_inventory_document: dict,
@@ -56,18 +58,80 @@ def compute_patient_summary(
             ) < date_utils.parse_datetime(safety_plan_document["assignedDateTime"])
 
     # assignedScheduledAssessments
-    assigned_scheduled_assessments = list(
-        filter(
-            lambda scheduled_assessment_current: (
-                (not scheduled_assessment_current["completed"])
-                and (
-                    date_utils.parse_date(scheduled_assessment_current["dueDate"])
-                    <= date_due
-                )
-            ),
-            scheduled_assessment_documents,
-        )
+    assigned_scheduled_assessments = []
+
+    # identify unique values of assessmentId
+    assessment_id_values = set(
+        scheduled_assessment_current["assessmentId"]
+        for scheduled_assessment_current in scheduled_assessment_documents
     )
+    for assessment_id_current in assessment_id_values:
+        scheduled_assessment_documents_current = copy.deepcopy(
+            scheduled_assessment_documents
+        )
+
+        # keep only scheduled assessments of this id
+        scheduled_assessment_documents_current = [
+            scheduled_assessment_current
+            for scheduled_assessment_current in scheduled_assessment_documents_current
+            if scheduled_assessment_current["assessmentId"] == assessment_id_current
+        ]
+
+        # keep only scheduled assessments that are due
+        scheduled_assessment_documents_current = [
+            scheduled_assessment_current
+            for scheduled_assessment_current in scheduled_assessment_documents_current
+            if date_utils.parse_date(scheduled_assessment_current["dueDate"])
+            <= date_due
+        ]
+
+        # sort by how recently they became due
+        scheduled_assessment_documents_current = sorted(
+            scheduled_assessment_documents_current,
+            key=lambda doc: date_utils.parse_date(doc["dueDate"]),
+        )
+
+        # Determine if we possibly have an assessment that is due
+        scheduled_assessment_currently_due = None
+        if scheduled_assessment_documents_current:
+            scheduled_assessment_currently_due = scheduled_assessment_documents_current[
+                -1
+            ]
+
+        # Check it is not already marked as completed
+        if scheduled_assessment_currently_due:
+            if scheduled_assessment_currently_due["completed"]:
+                scheduled_assessment_currently_due = None
+
+        # We have had low confidence in the code which marks completed.
+        # Check the possibility that a patient has submitted an assessment log since this was due.
+        if scheduled_assessment_currently_due:
+            # gather patient-submitted assessment logs for this assessment
+            assessment_log_documents_current = [
+                assessment_log_current
+                for assessment_log_current in assessment_log_documents
+                if assessment_log_current["assessmentId"] == assessment_id_current
+                and assessment_log_current["patientSubmitted"]
+            ]
+
+            if assessment_log_documents_current:
+                # determine which was most recent
+                assessment_log_most_recent = sorted(
+                    assessment_log_documents_current,
+                    key=lambda doc: date_utils.parse_datetime(doc["recordedDateTime"]),
+                )[-1]
+
+                # if it came after we were due, then we were already submitted
+                if date_utils.parse_datetime(
+                    assessment_log_most_recent["recordedDateTime"]
+                ).date() >= date_utils.parse_date(
+                    scheduled_assessment_currently_due["dueDate"]
+                ):
+                    scheduled_assessment_currently_due = None
+
+        # This assessment appears due
+        if scheduled_assessment_currently_due:
+            assigned_scheduled_assessments.append(scheduled_assessment_currently_due)
 
     return {
         "assignedValuesInventory": assigned_values_inventory,

--- a/server_flask/blueprints/patient/summary.py
+++ b/server_flask/blueprints/patient/summary.py
@@ -6,6 +6,7 @@ import request_context
 import request_utils
 import scope.database.date_utils as date_utils
 import scope.database.patient.activities
+import scope.database.patient.assessment_logs
 import scope.database.patient.safety_plan
 import scope.database.patient.scheduled_assessments
 import scope.database.patient.values_inventory
@@ -36,6 +37,13 @@ def get_patient_summary(patient_id):
     )
     activity_documents = activity_documents or []
 
+    assessment_log_documents = (
+        scope.database.patient.assessment_logs.get_assessment_logs(
+            collection=patient_collection
+        )
+    )
+    assessment_log_documents = assessment_log_documents or []
+
     safety_plan_document = scope.database.patient.safety_plan.get_safety_plan(
         collection=patient_collection,
     )
@@ -63,6 +71,7 @@ def get_patient_summary(patient_id):
 
     return scope.utils.compute_patient_summary.compute_patient_summary(
         activity_documents=activity_documents,
+        assessment_log_documents=assessment_log_documents,
         safety_plan_document=safety_plan_document,
         scheduled_assessment_documents=scheduled_assessment_documents,
         values_inventory_document=values_inventory_document,

--- a/web_patient/src/stores/PatientStore.ts
+++ b/web_patient/src/stores/PatientStore.ts
@@ -240,22 +240,27 @@ export class PatientStore implements IPatientStore {
   }
 
   @computed public get assessmentsToComplete() {
+    // This will use all the server logic to obtain only a valid scheduled assessment.
     const scheduledAssessments =
       this.config?.assignedScheduledAssessments || [];
-    // Returns deduped list of assessments to complete
-    const latestAssessments: IScheduledAssessment[] = [];
-    const assessmentGroups = _.groupBy(
-      scheduledAssessments,
-      (a) => a.assessmentId,
-    );
 
-    for (var assessmentId in assessmentGroups) {
-      const group = assessmentGroups[assessmentId];
-      group.sort((a, b) => compareDesc(a.dueDateTime, b.dueDateTime));
-      latestAssessments.push(group[0]);
-    }
+    return scheduledAssessments;
 
-    return latestAssessments;
+    // Therefore, none of this is needed.
+    // // Returns deduped list of assessments to complete
+    // const latestAssessments: IScheduledAssessment[] = [];
+    // const assessmentGroups = _.groupBy(
+    //   scheduledAssessments,
+    //   (a) => a.assessmentId,
+    // );
+    //
+    // for (var assessmentId in assessmentGroups) {
+    //   const group = assessmentGroups[assessmentId];
+    //   group.sort((a, b) => compareDesc(a.dueDateTime, b.dueDateTime));
+    //   latestAssessments.push(group[0]);
+    // }
+    //
+    // return latestAssessments;
   }
 
   @computed public get assessmentLogs() {


### PR DESCRIPTION
compute_patient_summary was previously returning all scheduled assessments that had not been marked complete.  This could include schedule assessment that came before a later scheduled assessment that had been completed.  Fixes this server logic, and have examined the client to confirm that the client relies on the server-provided filtering.